### PR TITLE
build(open62541): DI Node ordering test case for open62541

### DIFF
--- a/nodesets/open62541/Opc.Ua.Di.NodeSet2_invalid_ordering.xml
+++ b/nodesets/open62541/Opc.Ua.Di.NodeSet2_invalid_ordering.xml
@@ -1,0 +1,5066 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+-->
+
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" LastModified="2021-09-07T00:00:00Z" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/DI/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/DI/" Version="1.03.1" PublicationDate="2021-09-07T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/" Version="1.04.4" PublicationDate="2020-01-08T00:00:00Z" />
+    </Model>
+  </Models>
+  <Aliases>
+    <Alias Alias="Boolean">i=1</Alias>
+    <Alias Alias="SByte">i=2</Alias>
+    <Alias Alias="Byte">i=3</Alias>
+    <Alias Alias="Int16">i=4</Alias>
+    <Alias Alias="UInt16">i=5</Alias>
+    <Alias Alias="Int32">i=6</Alias>
+    <Alias Alias="UInt32">i=7</Alias>
+    <Alias Alias="Int64">i=8</Alias>
+    <Alias Alias="UInt64">i=9</Alias>
+    <Alias Alias="Float">i=10</Alias>
+    <Alias Alias="Double">i=11</Alias>
+    <Alias Alias="DateTime">i=13</Alias>
+    <Alias Alias="String">i=12</Alias>
+    <Alias Alias="ByteString">i=15</Alias>
+    <Alias Alias="Guid">i=14</Alias>
+    <Alias Alias="XmlElement">i=16</Alias>
+    <Alias Alias="NodeId">i=17</Alias>
+    <Alias Alias="ExpandedNodeId">i=18</Alias>
+    <Alias Alias="QualifiedName">i=20</Alias>
+    <Alias Alias="LocalizedText">i=21</Alias>
+    <Alias Alias="StatusCode">i=19</Alias>
+    <Alias Alias="Structure">i=22</Alias>
+    <Alias Alias="Number">i=26</Alias>
+    <Alias Alias="Integer">i=27</Alias>
+    <Alias Alias="UInteger">i=28</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasProperty">i=46</Alias>
+    <Alias Alias="Organizes">i=35</Alias>
+    <Alias Alias="HasEventSource">i=36</Alias>
+    <Alias Alias="HasNotifier">i=48</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="HasEncoding">i=38</Alias>
+    <Alias Alias="HasDescription">i=39</Alias>
+    <Alias Alias="HasCause">i=53</Alias>
+    <Alias Alias="ToState">i=52</Alias>
+    <Alias Alias="FromState">i=51</Alias>
+    <Alias Alias="HasEffect">i=54</Alias>
+    <Alias Alias="HasTrueSubState">i=9004</Alias>
+    <Alias Alias="HasFalseSubState">i=9005</Alias>
+    <Alias Alias="HasDictionaryEntry">i=17597</Alias>
+    <Alias Alias="HasCondition">i=9006</Alias>
+    <Alias Alias="HasGuard">i=15112</Alias>
+    <Alias Alias="HasAddIn">i=17604</Alias>
+    <Alias Alias="HasInterface">i=17603</Alias>
+  </Aliases>
+  <UAVariable NodeId="ns=1;i=15002" BrowseName="NamespaceUri" ParentNodeId="ns=1;i=15001" DataType="String">
+    <DisplayName>NamespaceUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/DI/</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15003" BrowseName="NamespaceVersion" ParentNodeId="ns=1;i=15001" DataType="String">
+    <DisplayName>NamespaceVersion</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1.03.1</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15004" BrowseName="NamespacePublicationDate" ParentNodeId="ns=1;i=15001" DataType="DateTime">
+    <DisplayName>NamespacePublicationDate</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <DateTime xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2021-09-07T00:00:00Z</DateTime>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15005" BrowseName="IsNamespaceSubset" ParentNodeId="ns=1;i=15001" DataType="Boolean">
+    <DisplayName>IsNamespaceSubset</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <Boolean xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">false</Boolean>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15006" BrowseName="StaticNodeIdTypes" ParentNodeId="ns=1;i=15001" DataType="i=256" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>StaticNodeIdTypes</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <ListOfInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <Int32>0</Int32>
+      </ListOfInt32>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15007" BrowseName="StaticNumericNodeIdRange" ParentNodeId="ns=1;i=15001" DataType="i=291" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>StaticNumericNodeIdRange</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <ListOfString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <String>1:2147483647</String>
+      </ListOfString>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15008" BrowseName="StaticStringNodeIdPattern" ParentNodeId="ns=1;i=15001" DataType="String">
+    <DisplayName>StaticStringNodeIdPattern</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd" />
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15031" BrowseName="DefaultRolePermissions" ParentNodeId="ns=1;i=15001" DataType="i=96" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>DefaultRolePermissions</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15032" BrowseName="DefaultUserRolePermissions" ParentNodeId="ns=1;i=15001" DataType="i=96" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>DefaultUserRolePermissions</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15033" BrowseName="DefaultAccessRestrictions" ParentNodeId="ns=1;i=15001" DataType="i=95">
+    <DisplayName>DefaultAccessRestrictions</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15001</Reference>
+    </References>
+  </UAVariable>
+  <UAReferenceType NodeId="ns=1;i=6030" BrowseName="1:ConnectsTo" Symmetric="true">
+    <DisplayName>ConnectsTo</DisplayName>
+    <Description>Used to indicate that source and target Node have a topological connection.</Description>
+    <Category>DI ConnectsTo</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/5.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=33</Reference>
+    </References>
+  </UAReferenceType>
+  <UAReferenceType NodeId="ns=1;i=6467" BrowseName="1:ConnectsToParent" Symmetric="true">
+    <DisplayName>ConnectsToParent</DisplayName>
+    <Description>Defines the parent (i.e. the communication Device) of a Network.</Description>
+    <Category>DI ConnectsTo</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/5.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=6030</Reference>
+    </References>
+  </UAReferenceType>
+  <UAReferenceType NodeId="ns=1;i=6031" BrowseName="1:IsOnline">
+    <DisplayName>IsOnline</DisplayName>
+    <Description>Used to bind the offline representation of a Device to the online representation.</Description>
+    <Category>DI Offline</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.3.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=44</Reference>
+    </References>
+    <InverseName>OnlineOf</InverseName>
+  </UAReferenceType>
+  <UAObject NodeId="ns=1;i=5001" BrowseName="1:DeviceSet">
+    <DisplayName>DeviceSet</DisplayName>
+    <Description>Contains all instances of devices</Description>
+    <Category>DI DeviceSet</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.9</Documentation>
+    <References>
+      <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15034" BrowseName="1:DeviceFeatures">
+    <DisplayName>DeviceFeatures</DisplayName>
+    <Category>DI DeviceSet</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.10</Documentation>
+    <References>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5001</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6078" BrowseName="1:NetworkSet">
+    <DisplayName>NetworkSet</DisplayName>
+    <Description>Contains all instances of communication networks</Description>
+    <Category>DI NetworkSet</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/5.6</Documentation>
+    <References>
+      <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6094" BrowseName="1:DeviceTopology">
+    <DisplayName>DeviceTopology</DisplayName>
+    <Description>Starting point of the configured device topology.</Description>
+    <Category>DI DeviceTopology</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6095</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6095" BrowseName="1:OnlineAccess" ParentNodeId="ns=1;i=6094" DataType="Boolean">
+    <DisplayName>OnlineAccess</DisplayName>
+    <Description>Hint of whether the Server is currently able to communicate to Devices in the topology.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6094</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:TopologyElementType" IsAbstract="true">
+    <DisplayName>TopologyElementType</DisplayName>
+    <Description>Defines the basic information components for all configurable elements in a device topology</Description>
+    <Category>DI Information Model</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=5002</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=5003</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6567</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6014</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6161</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=5002" BrowseName="1:ParameterSet" ParentNodeId="ns=1;i=1001">
+    <DisplayName>ParameterSet</DisplayName>
+    <Description>Flat list of Parameters</Description>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6017</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6017" BrowseName="1:&lt;ParameterIdentifier&gt;" SymbolicName="ParameterIdentifier" ParentNodeId="ns=1;i=5002">
+    <DisplayName>&lt;ParameterIdentifier&gt;</DisplayName>
+    <Description>A parameter which belongs to the topology element.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5002</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=5003" BrowseName="1:MethodSet" ParentNodeId="ns=1;i=1001">
+    <DisplayName>MethodSet</DisplayName>
+    <Description>Flat list of Methods</Description>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6567" BrowseName="1:&lt;GroupIdentifier&gt;" SymbolicName="GroupIdentifier" ParentNodeId="ns=1;i=1001">
+    <DisplayName>&lt;GroupIdentifier&gt;</DisplayName>
+    <Description>An application specific functional group used to organize parameters and methods.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11508</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6014" BrowseName="1:Identification" ParentNodeId="ns=1;i=1001">
+    <DisplayName>Identification</DisplayName>
+    <Description>Used to organize parameters for identification of this TopologyElement</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6161" BrowseName="1:Lock" ParentNodeId="ns=1;i=1001">
+    <DisplayName>Lock</DisplayName>
+    <Description>Used to lock the topology element.</Description>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6468</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6163</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6164</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6165</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6166</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6169</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6171</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6173</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6388</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6468" BrowseName="1:Locked" ParentNodeId="ns=1;i=6161" DataType="Boolean">
+    <DisplayName>Locked</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6163" BrowseName="1:LockingClient" ParentNodeId="ns=1;i=6161" DataType="String">
+    <DisplayName>LockingClient</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6164" BrowseName="1:LockingUser" ParentNodeId="ns=1;i=6161" DataType="String">
+    <DisplayName>LockingUser</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6165" BrowseName="1:RemainingLockTime" ParentNodeId="ns=1;i=6161" DataType="i=290">
+    <DisplayName>RemainingLockTime</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6166" BrowseName="1:InitLock" ParentNodeId="ns=1;i=6161" MethodDeclarationId="ns=1;i=6393">
+    <DisplayName>InitLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6167</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6168</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6167" BrowseName="InputArguments" ParentNodeId="ns=1;i=6166" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6166</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>Context</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6168" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6166" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6166</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>InitLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6169" BrowseName="1:RenewLock" ParentNodeId="ns=1;i=6161" MethodDeclarationId="ns=1;i=6396">
+    <DisplayName>RenewLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6170</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6170" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6169" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6169</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>RenewLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6171" BrowseName="1:ExitLock" ParentNodeId="ns=1;i=6161" MethodDeclarationId="ns=1;i=6398">
+    <DisplayName>ExitLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6172</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6172" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6171" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6171</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ExitLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6173" BrowseName="1:BreakLock" ParentNodeId="ns=1;i=6161" MethodDeclarationId="ns=1;i=6400">
+    <DisplayName>BreakLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6174</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6161</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6174" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6173" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6173</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>BreakLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=15035" BrowseName="1:IVendorNameplateType" IsAbstract="true">
+    <DisplayName>IVendorNameplateType</DisplayName>
+    <Category>DI Nameplate</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.5.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15036</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15037</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15038</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15039</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15040</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15041</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15042</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15043</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15044</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15045</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15046</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15047</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=23</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=24</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=17602</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=15036" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=15035" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15037" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15038" BrowseName="1:Model" ParentNodeId="ns=1;i=15035" DataType="LocalizedText">
+    <DisplayName>Model</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15039" BrowseName="1:HardwareRevision" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>HardwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15040" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15041" BrowseName="1:DeviceRevision" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>DeviceRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15042" BrowseName="1:ProductCode" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>ProductCode</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15043" BrowseName="1:DeviceManual" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>DeviceManual</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15044" BrowseName="1:DeviceClass" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>DeviceClass</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15045" BrowseName="1:SerialNumber" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>SerialNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15046" BrowseName="1:ProductInstanceUri" ParentNodeId="ns=1;i=15035" DataType="String">
+    <DisplayName>ProductInstanceUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15047" BrowseName="1:RevisionCounter" ParentNodeId="ns=1;i=15035" DataType="Int32">
+    <DisplayName>RevisionCounter</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=23" BrowseName="1:SoftwareReleaseDate" ParentNodeId="ns=1;i=15035" DataType="DateTime">
+    <DisplayName>SoftwareReleaseDate</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=24" BrowseName="1:PatchIdentifiers" ParentNodeId="ns=1;i=15035" DataType="String" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>PatchIdentifiers</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15035</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=15048" BrowseName="1:ITagNameplateType" IsAbstract="true">
+    <DisplayName>ITagNameplateType</DisplayName>
+    <Category>DI TagNameplate</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.5.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15049</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15050</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=17602</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=15049" BrowseName="1:AssetId" ParentNodeId="ns=1;i=15048" DataType="String">
+    <DisplayName>AssetId</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15048</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15050" BrowseName="1:ComponentName" ParentNodeId="ns=1;i=15048" DataType="LocalizedText">
+    <DisplayName>ComponentName</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15048</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=15051" BrowseName="1:IDeviceHealthType" IsAbstract="true">
+    <DisplayName>IDeviceHealthType</DisplayName>
+    <Category>DI DeviceHealth</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.5.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=15052</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15053</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=17602</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=15052" BrowseName="1:DeviceHealth" ParentNodeId="ns=1;i=15051" DataType="ns=1;i=6244">
+    <DisplayName>DeviceHealth</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15051</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=15053" BrowseName="1:DeviceHealthAlarms" ParentNodeId="ns=1;i=15051">
+    <DisplayName>DeviceHealthAlarms</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15051</Reference>
+    </References>
+  </UAObject>
+  <UAObjectType NodeId="ns=1;i=15054" BrowseName="1:ISupportInfoType" IsAbstract="true">
+    <DisplayName>ISupportInfoType</DisplayName>
+    <Category>DI DeviceSupportInfo</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.5.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=15055</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15057</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15059</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15061</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=17602</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=15055" BrowseName="1:DeviceTypeImage" ParentNodeId="ns=1;i=15054">
+    <DisplayName>DeviceTypeImage</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=15056</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15054</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=15056" BrowseName="1:&lt;ImageIdentifier&gt;" SymbolicName="ImageIdentifier" ParentNodeId="ns=1;i=15055" DataType="i=30">
+    <DisplayName>&lt;ImageIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15055</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=15057" BrowseName="1:Documentation" ParentNodeId="ns=1;i=15054">
+    <DisplayName>Documentation</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=15058</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15054</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=15058" BrowseName="1:&lt;DocumentIdentifier&gt;" SymbolicName="DocumentIdentifier" ParentNodeId="ns=1;i=15057" DataType="ByteString">
+    <DisplayName>&lt;DocumentIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15057</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=15059" BrowseName="1:ProtocolSupport" ParentNodeId="ns=1;i=15054">
+    <DisplayName>ProtocolSupport</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=15060</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15054</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=15060" BrowseName="1:&lt;ProtocolSupportIdentifier&gt;" SymbolicName="ProtocolSupportIdentifier" ParentNodeId="ns=1;i=15059" DataType="ByteString">
+    <DisplayName>&lt;ProtocolSupportIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15059</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=15061" BrowseName="1:ImageSet" ParentNodeId="ns=1;i=15054">
+    <DisplayName>ImageSet</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=15062</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15054</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=15062" BrowseName="1:&lt;ImageIdentifier&gt;" SymbolicName="ImageIdentifier" ParentNodeId="ns=1;i=15061" DataType="i=30">
+    <DisplayName>&lt;ImageIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=15061</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=15063" BrowseName="1:ComponentType" IsAbstract="true">
+    <DisplayName>ComponentType</DisplayName>
+    <Category>DI Information Model</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15086</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15087</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15088</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15089</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15090</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15091</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15092</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15093</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15094</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15095</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15096</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15097</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15098</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15099</Reference>
+      <Reference ReferenceType="HasInterface">ns=1;i=15035</Reference>
+      <Reference ReferenceType="HasInterface">ns=1;i=15048</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=15086" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=15063" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15087" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15088" BrowseName="1:Model" ParentNodeId="ns=1;i=15063" DataType="LocalizedText">
+    <DisplayName>Model</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15089" BrowseName="1:HardwareRevision" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>HardwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15090" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15091" BrowseName="1:DeviceRevision" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>DeviceRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15092" BrowseName="1:ProductCode" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>ProductCode</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15093" BrowseName="1:DeviceManual" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>DeviceManual</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15094" BrowseName="1:DeviceClass" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>DeviceClass</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15095" BrowseName="1:SerialNumber" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>SerialNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15096" BrowseName="1:ProductInstanceUri" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>ProductInstanceUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15097" BrowseName="1:RevisionCounter" ParentNodeId="ns=1;i=15063" DataType="Int32">
+    <DisplayName>RevisionCounter</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15098" BrowseName="1:AssetId" ParentNodeId="ns=1;i=15063" DataType="String">
+    <DisplayName>AssetId</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15099" BrowseName="1:ComponentName" ParentNodeId="ns=1;i=15063" DataType="LocalizedText">
+    <DisplayName>ComponentName</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:DeviceType" IsAbstract="true">
+    <DisplayName>DeviceType</DisplayName>
+    <Description>Defines the basic information components for all configurable elements in a device topology</Description>
+    <Category>DI DeviceType</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.7</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6003</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15100</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6004</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6008</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6007</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6006</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15101</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6005</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6470</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6001</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15102</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6002</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6571</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6208</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15105</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6209</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6211</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6213</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6215</Reference>
+      <Reference ReferenceType="HasInterface">ns=1;i=15054</Reference>
+      <Reference ReferenceType="HasInterface">ns=1;i=15051</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=6003" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=1002" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <Description>Name of the company that manufactured the device</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15100" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6004" BrowseName="1:Model" ParentNodeId="ns=1;i=1002" DataType="LocalizedText">
+    <DisplayName>Model</DisplayName>
+    <Description>Model name of the device</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6008" BrowseName="1:HardwareRevision" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>HardwareRevision</DisplayName>
+    <Description>Revision level of the hardware of the device</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6007" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <Description>Revision level of the software/firmware of the device</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6006" BrowseName="1:DeviceRevision" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>DeviceRevision</DisplayName>
+    <Description>Overall revision level of the device</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15101" BrowseName="1:ProductCode" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>ProductCode</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6005" BrowseName="1:DeviceManual" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>DeviceManual</DisplayName>
+    <Description>Address (pathname in the file system or a URL | Web address) of user manual for the device</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6470" BrowseName="1:DeviceClass" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>DeviceClass</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6001" BrowseName="1:SerialNumber" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>SerialNumber</DisplayName>
+    <Description>Identifier that uniquely identifies, within a manufacturer, a device instance</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15102" BrowseName="1:ProductInstanceUri" ParentNodeId="ns=1;i=1002" DataType="String">
+    <DisplayName>ProductInstanceUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6002" BrowseName="1:RevisionCounter" ParentNodeId="ns=1;i=1002" DataType="Int32">
+    <DisplayName>RevisionCounter</DisplayName>
+    <Description>An incremental counter indicating the number of times the static data within the Device has been modified</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=6571" BrowseName="1:&lt;CPIdentifier&gt;" SymbolicName="CPIdentifier" ParentNodeId="ns=1;i=1002">
+    <DisplayName>&lt;CPIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6592</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6308</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11508</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6592" BrowseName="1:NetworkAddress" ParentNodeId="ns=1;i=6571">
+    <DisplayName>NetworkAddress</DisplayName>
+    <Description>The address of the device on this network.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6571</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6208" BrowseName="1:DeviceHealth" ParentNodeId="ns=1;i=1002" DataType="ns=1;i=6244">
+    <DisplayName>DeviceHealth</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=15105" BrowseName="1:DeviceHealthAlarms" ParentNodeId="ns=1;i=1002">
+    <DisplayName>DeviceHealthAlarms</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6209" BrowseName="1:DeviceTypeImage" ParentNodeId="ns=1;i=1002">
+    <DisplayName>DeviceTypeImage</DisplayName>
+    <Description>Organizes pictures of the device.</Description>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6210</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6210" BrowseName="1:&lt;ImageIdentifier&gt;" SymbolicName="ImageIdentifier" ParentNodeId="ns=1;i=6209" DataType="i=30">
+    <DisplayName>&lt;ImageIdentifier&gt;</DisplayName>
+    <Description>An image of the device.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6209</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=6211" BrowseName="1:Documentation" ParentNodeId="ns=1;i=1002">
+    <DisplayName>Documentation</DisplayName>
+    <Description>Organizes documents for the device.</Description>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6212</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6212" BrowseName="1:&lt;DocumentIdentifier&gt;" SymbolicName="DocumentIdentifier" ParentNodeId="ns=1;i=6211" DataType="ByteString">
+    <DisplayName>&lt;DocumentIdentifier&gt;</DisplayName>
+    <Description>A document for the device.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6211</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=6213" BrowseName="1:ProtocolSupport" ParentNodeId="ns=1;i=1002">
+    <DisplayName>ProtocolSupport</DisplayName>
+    <Description>Protocol-specific files for the device.</Description>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6214</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6214" BrowseName="1:&lt;ProtocolSupportIdentifier&gt;" SymbolicName="ProtocolSupportIdentifier" ParentNodeId="ns=1;i=6213" DataType="ByteString">
+    <DisplayName>&lt;ProtocolSupportIdentifier&gt;</DisplayName>
+    <Description>A protocol-specific file for the device.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6213</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=6215" BrowseName="1:ImageSet" ParentNodeId="ns=1;i=1002">
+    <DisplayName>ImageSet</DisplayName>
+    <Description>Organizes images that are used within UIElements.</Description>
+    <Documentation>https://reference.opcfoundation.org/v104/DI/v102/docs/5.5.5/#5.5.5.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6216</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6216" BrowseName="1:&lt;ImageIdentifier&gt;" SymbolicName="ImageIdentifier" ParentNodeId="ns=1;i=6215" DataType="i=30">
+    <DisplayName>&lt;ImageIdentifier&gt;</DisplayName>
+    <Description>An image for a UIElement.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6215</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=15106" BrowseName="1:SoftwareType">
+    <DisplayName>SoftwareType</DisplayName>
+    <Category>DI Software Component</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.8</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15129</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15131</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15133</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=15063</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=15129" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=15106" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15106</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15131" BrowseName="1:Model" ParentNodeId="ns=1;i=15106" DataType="LocalizedText">
+    <DisplayName>Model</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15106</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15133" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=15106" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15106</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=1003" BrowseName="1:BlockType" IsAbstract="true">
+    <DisplayName>BlockType</DisplayName>
+    <Description>Adds the concept of Blocks needed for block-oriented FieldDevices</Description>
+    <Category>DI Blocks</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.11</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6009</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6010</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6011</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6012</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6013</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=6009" BrowseName="1:RevisionCounter" ParentNodeId="ns=1;i=1003" DataType="Int32">
+    <DisplayName>RevisionCounter</DisplayName>
+    <Description>Incremental counter indicating the number of times the static data within the Block has been modified</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1003</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6010" BrowseName="1:ActualMode" ParentNodeId="ns=1;i=1003" DataType="LocalizedText">
+    <DisplayName>ActualMode</DisplayName>
+    <Description>Current mode of operation the Block is able to achieve</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1003</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6011" BrowseName="1:PermittedMode" ParentNodeId="ns=1;i=1003" DataType="LocalizedText" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>PermittedMode</DisplayName>
+    <Description>Modes of operation that are allowed for the Block based on application requirements</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1003</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6012" BrowseName="1:NormalMode" ParentNodeId="ns=1;i=1003" DataType="LocalizedText" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>NormalMode</DisplayName>
+    <Description>Mode the Block should be set to during normal operating conditions</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1003</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6013" BrowseName="1:TargetMode" ParentNodeId="ns=1;i=1003" DataType="LocalizedText" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>TargetMode</DisplayName>
+    <Description>Mode of operation that is desired for the Block</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1003</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=15143" BrowseName="1:DeviceHealthDiagnosticAlarmType" IsAbstract="true">
+    <DisplayName>DeviceHealthDiagnosticAlarmType</DisplayName>
+    <Category>DI HealthDiagnosticsAlarm</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.12.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=18347</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=15292" BrowseName="1:FailureAlarmType">
+    <DisplayName>FailureAlarmType</DisplayName>
+    <Category>DI HealthDiagnosticsAlarm</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.12.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=15143</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=15441" BrowseName="1:CheckFunctionAlarmType">
+    <DisplayName>CheckFunctionAlarmType</DisplayName>
+    <Category>DI HealthDiagnosticsAlarm</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.12.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=15143</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=15590" BrowseName="1:OffSpecAlarmType">
+    <DisplayName>OffSpecAlarmType</DisplayName>
+    <Category>DI HealthDiagnosticsAlarm</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.12.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=15143</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=15739" BrowseName="1:MaintenanceRequiredAlarmType">
+    <DisplayName>MaintenanceRequiredAlarmType</DisplayName>
+    <Category>DI HealthDiagnosticsAlarm</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.12.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=15143</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=1004" BrowseName="1:ConfigurableObjectType">
+    <DisplayName>ConfigurableObjectType</DisplayName>
+    <Description>Defines a general pattern to expose and configure modular components</Description>
+    <Category>DI Information Model</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/9.2.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=5004</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6026</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=5004" BrowseName="1:SupportedTypes" ParentNodeId="ns=1;i=1004">
+    <DisplayName>SupportedTypes</DisplayName>
+    <Description>Folder maintaining the set of (sub-types of) BaseObjectTypes that can be instantiated in the ConfigurableComponent</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1004</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6026" BrowseName="1:&lt;ObjectIdentifier&gt;" SymbolicName="ObjectIdentifier" ParentNodeId="ns=1;i=1004">
+    <DisplayName>&lt;ObjectIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11508</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1004</Reference>
+    </References>
+  </UAObject>
+  <UAObjectType NodeId="ns=1;i=1005" BrowseName="1:FunctionalGroupType">
+    <DisplayName>FunctionalGroupType</DisplayName>
+    <Description>FolderType is used to organize the Parameters and Methods from the complete set (ParameterSet, MethodSet) with regard to their application</Description>
+    <Category>DI Information Model</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.4.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6027</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6243</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=61</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=6027" BrowseName="1:&lt;GroupIdentifier&gt;" SymbolicName="GroupIdentifier" ParentNodeId="ns=1;i=1005">
+    <DisplayName>&lt;GroupIdentifier&gt;</DisplayName>
+    <Description>An application specific functional group used to organize parameters and methods.</Description>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6242</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11508</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1005</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6242" BrowseName="1:UIElement" ParentNodeId="ns=1;i=6027">
+    <DisplayName>UIElement</DisplayName>
+    <Description>A user interface element assigned to this group.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6246</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6027</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6243" BrowseName="1:UIElement" ParentNodeId="ns=1;i=1005">
+    <DisplayName>UIElement</DisplayName>
+    <Description>A user interface element assigned to this group.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6246</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1005</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=1006" BrowseName="1:ProtocolType">
+    <DisplayName>ProtocolType</DisplayName>
+    <Description>General structure of a Protocol ObjectType</Description>
+    <Category>DI Network</Category>
+    <Category>DI Protocol</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/5.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UADataType NodeId="ns=1;i=6244" BrowseName="1:DeviceHealthEnumeration">
+    <DisplayName>DeviceHealthEnumeration</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.5.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6450</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=29</Reference>
+    </References>
+    <Definition Name="1:DeviceHealthEnumeration">
+      <Field Name="NORMAL" Value="0">
+        <Description>This device functions normally.</Description>
+      </Field>
+      <Field Name="FAILURE" Value="1">
+        <Description>Malfunction of the device or any of its peripherals.</Description>
+      </Field>
+      <Field Name="CHECK_FUNCTION" Value="2">
+        <Description>Functional checks are currently performed.</Description>
+      </Field>
+      <Field Name="OFF_SPEC" Value="3">
+        <Description>The device is currently working outside of its specified range or that internal diagnoses indicate deviations from measured or set values.</Description>
+      </Field>
+      <Field Name="MAINTENANCE_REQUIRED" Value="4">
+        <Description>This element is working, but a maintenance operation is required.</Description>
+      </Field>
+    </Definition>
+  </UADataType>
+  <UAVariable NodeId="ns=1;i=6450" BrowseName="EnumStrings" ParentNodeId="ns=1;i=6244" DataType="LocalizedText" ValueRank="1" ArrayDimensions="5">
+    <DisplayName>EnumStrings</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6244</Reference>
+    </References>
+    <Value>
+      <ListOfLocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <LocalizedText>
+          <Text>NORMAL</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>FAILURE</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>CHECK_FUNCTION</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>OFF_SPEC</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>MAINTENANCE_REQUIRED</Text>
+        </LocalizedText>
+      </ListOfLocalizedText>
+    </Value>
+  </UAVariable>
+  <UAVariableType NodeId="ns=1;i=6246" BrowseName="1:UIElementType" IsAbstract="true">
+    <DisplayName>UIElementType</DisplayName>
+    <Description>The base type for all UI Element Types.</Description>
+    <Category>DI Information Model</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/4.4.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=63</Reference>
+    </References>
+  </UAVariableType>
+  <UAObjectType NodeId="ns=1;i=6247" BrowseName="1:NetworkType">
+    <DisplayName>NetworkType</DisplayName>
+    <Description>Represents the communication means for Devices that are connected to it.</Description>
+    <Category>DI Network</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/5.3</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6596</Reference>
+      <Reference ReferenceType="ns=1;i=6030">ns=1;i=6248</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6294</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=6596" BrowseName="1:&lt;ProfileIdentifier&gt;" SymbolicName="ProfileIdentifier" ParentNodeId="ns=1;i=6247">
+    <DisplayName>&lt;ProfileIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1006</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6247</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6248" BrowseName="1:&lt;CPIdentifier&gt;" SymbolicName="CPIdentifier" ParentNodeId="ns=1;i=6247">
+    <DisplayName>&lt;CPIdentifier&gt;</DisplayName>
+    <Description>The ConnectionPoint(s) that have been configured for this Network.</Description>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6292</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6308</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11508</Reference>
+      <Reference ReferenceType="ns=1;i=6030" IsForward="false">ns=1;i=6247</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6292" BrowseName="1:NetworkAddress" ParentNodeId="ns=1;i=6248">
+    <DisplayName>NetworkAddress</DisplayName>
+    <Description>The address of the device on this network.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6248</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6294" BrowseName="1:Lock" ParentNodeId="ns=1;i=6247">
+    <DisplayName>Lock</DisplayName>
+    <Description>Used to lock the Network.</Description>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6497</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6296</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6297</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6298</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6299</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6302</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6304</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6306</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6388</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6247</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6497" BrowseName="1:Locked" ParentNodeId="ns=1;i=6294" DataType="Boolean">
+    <DisplayName>Locked</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6296" BrowseName="1:LockingClient" ParentNodeId="ns=1;i=6294" DataType="String">
+    <DisplayName>LockingClient</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6297" BrowseName="1:LockingUser" ParentNodeId="ns=1;i=6294" DataType="String">
+    <DisplayName>LockingUser</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6298" BrowseName="1:RemainingLockTime" ParentNodeId="ns=1;i=6294" DataType="i=290">
+    <DisplayName>RemainingLockTime</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6299" BrowseName="1:InitLock" ParentNodeId="ns=1;i=6294" MethodDeclarationId="ns=1;i=6393">
+    <DisplayName>InitLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6300</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6301</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6300" BrowseName="InputArguments" ParentNodeId="ns=1;i=6299" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6299</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>Context</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6301" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6299" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6299</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>InitLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6302" BrowseName="1:RenewLock" ParentNodeId="ns=1;i=6294" MethodDeclarationId="ns=1;i=6396">
+    <DisplayName>RenewLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6303</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6303" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6302" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6302</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>RenewLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6304" BrowseName="1:ExitLock" ParentNodeId="ns=1;i=6294" MethodDeclarationId="ns=1;i=6398">
+    <DisplayName>ExitLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6305</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6305" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6304" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6304</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ExitLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6306" BrowseName="1:BreakLock" ParentNodeId="ns=1;i=6294" MethodDeclarationId="ns=1;i=6400">
+    <DisplayName>BreakLock</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6307</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6294</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6307" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6306" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6306</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>BreakLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=6308" BrowseName="1:ConnectionPointType" IsAbstract="true">
+    <DisplayName>ConnectionPointType</DisplayName>
+    <Description>Represents the interface (interface card) of a Device to a Network.</Description>
+    <Category>DI ConnectionPoint</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/5.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6354</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6499</Reference>
+      <Reference ReferenceType="ns=1;i=6030">ns=1;i=6599</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=6354" BrowseName="1:NetworkAddress" ParentNodeId="ns=1;i=6308">
+    <DisplayName>NetworkAddress</DisplayName>
+    <Description>The address of the device on this network.</Description>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6308</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6499" BrowseName="1:&lt;ProfileIdentifier&gt;" SymbolicName="ProfileIdentifier" ParentNodeId="ns=1;i=6308">
+    <DisplayName>&lt;ProfileIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=1006</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11510</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6308</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6599" BrowseName="1:&lt;NetworkIdentifier&gt;" SymbolicName="NetworkIdentifier" ParentNodeId="ns=1;i=6308">
+    <DisplayName>&lt;NetworkIdentifier&gt;</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=6247</Reference>
+      <Reference ReferenceType="HasModellingRule">i=11508</Reference>
+      <Reference ReferenceType="ns=1;i=6030" IsForward="false">ns=1;i=6308</Reference>
+    </References>
+  </UAObject>
+  <UADataType NodeId="ns=1;i=6522" BrowseName="1:FetchResultDataType" IsAbstract="true">
+    <DisplayName>FetchResultDataType</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+    </References>
+    <Definition Name="1:FetchResultDataType" />
+  </UADataType>
+  <UADataType NodeId="ns=1;i=15888" BrowseName="1:TransferResultErrorDataType">
+    <DisplayName>TransferResultErrorDataType</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=6522</Reference>
+    </References>
+    <Definition Name="1:TransferResultErrorDataType">
+      <Field Name="Status" DataType="i=6" />
+      <Field Name="Diagnostics" DataType="i=25" />
+    </Definition>
+  </UADataType>
+  <UADataType NodeId="ns=1;i=15889" BrowseName="1:TransferResultDataDataType">
+    <DisplayName>TransferResultDataDataType</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=6522</Reference>
+    </References>
+    <Definition Name="1:TransferResultDataDataType">
+      <Field Name="SequenceNumber" DataType="i=6" />
+      <Field Name="EndOfResults" DataType="i=1" />
+      <Field Name="ParameterDefs" DataType="ns=1;i=6525" ValueRank="1" />
+    </Definition>
+  </UADataType>
+  <UADataType NodeId="ns=1;i=6525" BrowseName="1:ParameterResultDataType">
+    <DisplayName>ParameterResultDataType</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+    </References>
+    <Definition Name="1:ParameterResultDataType">
+      <Field Name="NodePath" DataType="i=20" ValueRank="1" />
+      <Field Name="StatusCode" DataType="i=19" />
+      <Field Name="Diagnostics" DataType="i=25" />
+    </Definition>
+  </UADataType>
+  <UAObjectType NodeId="ns=1;i=6526" BrowseName="1:TransferServicesType">
+    <DisplayName>TransferServicesType</DisplayName>
+    <Category>DI Offline</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=6527</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6529</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6531</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAMethod NodeId="ns=1;i=6527" BrowseName="1:TransferToDevice" ParentNodeId="ns=1;i=6526">
+    <DisplayName>TransferToDevice</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.4</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6528</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6526</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6528" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6527" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6527</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>TransferID</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>InitTransferStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6529" BrowseName="1:TransferFromDevice" ParentNodeId="ns=1;i=6526">
+    <DisplayName>TransferFromDevice</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6530</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6526</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6530" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6529" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6529</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>TransferID</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>InitTransferStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6531" BrowseName="1:FetchTransferResultData" ParentNodeId="ns=1;i=6526">
+    <DisplayName>FetchTransferResultData</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/6.4.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6532</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6533</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6526</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6532" BrowseName="InputArguments" ParentNodeId="ns=1;i=6531" DataType="i=296" ValueRank="1" ArrayDimensions="4">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6531</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>TransferID</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>SequenceNumber</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>MaxParameterResultsToReturn</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>OmitGoodResults</Name>
+              <DataType>
+                <Identifier>i=1</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6533" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6531" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6531</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FetchResultData</Name>
+              <DataType>
+                <Identifier>i=22</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6387" BrowseName="1:MaxInactiveLockTime" DataType="i=290">
+    <DisplayName>MaxInactiveLockTime</DisplayName>
+    <Description>Server-specific period of time in milliseconds until the Server will revoke a lock.</Description>
+    <References>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=2268</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=6388" BrowseName="1:LockingServicesType">
+    <DisplayName>LockingServicesType</DisplayName>
+    <Description>An interface for Locking.</Description>
+    <Category>DI Locking</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/7.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15890</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6534</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6390</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6391</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6392</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6393</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6396</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6398</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6400</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=15890" BrowseName="DefaultInstanceBrowseName" ParentNodeId="ns=1;i=6388" DataType="QualifiedName">
+    <DisplayName>DefaultInstanceBrowseName</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+    <Value>
+      <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <NamespaceIndex>1</NamespaceIndex>
+        <Name>Lock</Name>
+      </QualifiedName>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6534" BrowseName="1:Locked" ParentNodeId="ns=1;i=6388" DataType="Boolean">
+    <DisplayName>Locked</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6390" BrowseName="1:LockingClient" ParentNodeId="ns=1;i=6388" DataType="String">
+    <DisplayName>LockingClient</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6391" BrowseName="1:LockingUser" ParentNodeId="ns=1;i=6388" DataType="String">
+    <DisplayName>LockingUser</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6392" BrowseName="1:RemainingLockTime" ParentNodeId="ns=1;i=6388" DataType="i=290">
+    <DisplayName>RemainingLockTime</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6393" BrowseName="1:InitLock" ParentNodeId="ns=1;i=6388">
+    <DisplayName>InitLock</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/7.5</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6394</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=6395</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6394" BrowseName="InputArguments" ParentNodeId="ns=1;i=6393" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6393</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>Context</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6395" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6393" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6393</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>InitLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6396" BrowseName="1:RenewLock" ParentNodeId="ns=1;i=6388">
+    <DisplayName>RenewLock</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/7.7</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6397</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6397" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6396" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6396</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>RenewLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6398" BrowseName="1:ExitLock" ParentNodeId="ns=1;i=6388">
+    <DisplayName>ExitLock</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/7.6</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6399</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6399" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6398" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6398</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ExitLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=6400" BrowseName="1:BreakLock" ParentNodeId="ns=1;i=6388">
+    <DisplayName>BreakLock</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/7.8</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6401</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6388</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=6401" BrowseName="OutputArguments" ParentNodeId="ns=1;i=6400" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6400</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>BreakLockStatus</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=1" BrowseName="1:SoftwareUpdateType">
+    <DisplayName>SoftwareUpdateType</DisplayName>
+    <Category>DI SU Software Update</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.1/#8.4.1.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=2</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=4</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=40</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=76</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=98</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=122</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=133</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=402</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=134</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=2" BrowseName="1:Loading" ParentNodeId="ns=1;i=1">
+    <DisplayName>Loading</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=135</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=4" BrowseName="1:PrepareForUpdate" ParentNodeId="ns=1;i=1">
+    <DisplayName>PrepareForUpdate</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=5</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=19</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=20</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=213</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=5" BrowseName="CurrentState" ParentNodeId="ns=1;i=4" DataType="LocalizedText">
+    <DisplayName>CurrentState</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2760</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=4</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6" BrowseName="Id" ParentNodeId="ns=1;i=5" DataType="NodeId">
+    <DisplayName>Id</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=19" BrowseName="1:Prepare" ParentNodeId="ns=1;i=4" MethodDeclarationId="ns=1;i=228">
+    <DisplayName>Prepare</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=4</Reference>
+    </References>
+  </UAMethod>
+  <UAMethod NodeId="ns=1;i=20" BrowseName="1:Abort" ParentNodeId="ns=1;i=4" MethodDeclarationId="ns=1;i=229">
+    <DisplayName>Abort</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=4</Reference>
+    </References>
+  </UAMethod>
+  <UAObject NodeId="ns=1;i=40" BrowseName="1:Installation" ParentNodeId="ns=1;i=1">
+    <DisplayName>Installation</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=41</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=61</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=249</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=41" BrowseName="CurrentState" ParentNodeId="ns=1;i=40" DataType="LocalizedText">
+    <DisplayName>CurrentState</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=42</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2760</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=40</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=42" BrowseName="Id" ParentNodeId="ns=1;i=41" DataType="NodeId">
+    <DisplayName>Id</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=41</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=61" BrowseName="1:Resume" ParentNodeId="ns=1;i=40" MethodDeclarationId="ns=1;i=270">
+    <DisplayName>Resume</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=40</Reference>
+    </References>
+  </UAMethod>
+  <UAObject NodeId="ns=1;i=76" BrowseName="1:PowerCycle" ParentNodeId="ns=1;i=1">
+    <DisplayName>PowerCycle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=77</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=285</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=77" BrowseName="CurrentState" ParentNodeId="ns=1;i=76" DataType="LocalizedText">
+    <DisplayName>CurrentState</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=78</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2760</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=76</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=78" BrowseName="Id" ParentNodeId="ns=1;i=77" DataType="NodeId">
+    <DisplayName>Id</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=77</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=98" BrowseName="1:Confirmation" ParentNodeId="ns=1;i=1">
+    <DisplayName>Confirmation</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=99</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=112</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=113</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=307</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=99" BrowseName="CurrentState" ParentNodeId="ns=1;i=98" DataType="LocalizedText">
+    <DisplayName>CurrentState</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=100</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2760</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=98</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=100" BrowseName="Id" ParentNodeId="ns=1;i=99" DataType="NodeId">
+    <DisplayName>Id</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=99</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=112" BrowseName="1:Confirm" ParentNodeId="ns=1;i=98" MethodDeclarationId="ns=1;i=321">
+    <DisplayName>Confirm</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=98</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=113" BrowseName="1:ConfirmationTimeout" ParentNodeId="ns=1;i=98" DataType="i=290">
+    <DisplayName>ConfirmationTimeout</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=98</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=122" BrowseName="1:Parameters" ParentNodeId="ns=1;i=1">
+    <DisplayName>Parameters</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=123</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=124</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=127</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=130</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=15744</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=123" BrowseName="ClientProcessingTimeout" ParentNodeId="ns=1;i=122" DataType="i=290">
+    <DisplayName>ClientProcessingTimeout</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=122</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=124" BrowseName="GenerateFileForRead" ParentNodeId="ns=1;i=122" MethodDeclarationId="i=15746">
+    <DisplayName>GenerateFileForRead</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=125</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=126</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=122</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=125" BrowseName="InputArguments" ParentNodeId="ns=1;i=124" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=124</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>GenerateOptions</Name>
+              <DataType>
+                <Identifier>i=24</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=126" BrowseName="OutputArguments" ParentNodeId="ns=1;i=124" DataType="i=296" ValueRank="1" ArrayDimensions="3">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=124</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>CompletionStateMachine</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=127" BrowseName="GenerateFileForWrite" ParentNodeId="ns=1;i=122" MethodDeclarationId="i=15749">
+    <DisplayName>GenerateFileForWrite</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=128</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=129</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=122</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=128" BrowseName="InputArguments" ParentNodeId="ns=1;i=127" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=127</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>GenerateOptions</Name>
+              <DataType>
+                <Identifier>i=24</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=129" BrowseName="OutputArguments" ParentNodeId="ns=1;i=127" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=127</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=130" BrowseName="CloseAndCommit" ParentNodeId="ns=1;i=122" MethodDeclarationId="i=15751">
+    <DisplayName>CloseAndCommit</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=131</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=132</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=122</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=131" BrowseName="InputArguments" ParentNodeId="ns=1;i=130" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=130</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=132" BrowseName="OutputArguments" ParentNodeId="ns=1;i=130" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=130</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>CompletionStateMachine</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=133" BrowseName="1:UpdateStatus" ParentNodeId="ns=1;i=1" DataType="LocalizedText">
+    <DisplayName>UpdateStatus</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=402" BrowseName="1:VendorErrorCode" ParentNodeId="ns=1;i=1" DataType="Int32">
+    <DisplayName>VendorErrorCode</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=134" BrowseName="DefaultInstanceBrowseName" ParentNodeId="ns=1;i=1" DataType="QualifiedName">
+    <DisplayName>DefaultInstanceBrowseName</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1</Reference>
+    </References>
+    <Value>
+      <QualifiedName xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <NamespaceIndex>1</NamespaceIndex>
+        <Name>SoftwareUpdate</Name>
+      </QualifiedName>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=135" BrowseName="1:SoftwareLoadingType" IsAbstract="true">
+    <DisplayName>SoftwareLoadingType</DisplayName>
+    <Category>DI SU Software Update</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.2/#8.4.2.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=136</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=136" BrowseName="1:UpdateKey" ParentNodeId="ns=1;i=135" DataType="String">
+    <DisplayName>UpdateKey</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=135</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=137" BrowseName="1:PackageLoadingType" IsAbstract="true">
+    <DisplayName>PackageLoadingType</DisplayName>
+    <Category>DI SU Software Update</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.3/#8.4.3.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=139</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=140</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=151</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=152</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=135</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=139" BrowseName="1:CurrentVersion" ParentNodeId="ns=1;i=137">
+    <DisplayName>CurrentVersion</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=345</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=346</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=347</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=212</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=137</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=345" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=139" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=139</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=346" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=139" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=139</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=347" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=139" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=139</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=140" BrowseName="1:FileTransfer" ParentNodeId="ns=1;i=137">
+    <DisplayName>FileTransfer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=141</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=142</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=145</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=148</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=15744</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=137</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=141" BrowseName="ClientProcessingTimeout" ParentNodeId="ns=1;i=140" DataType="i=290">
+    <DisplayName>ClientProcessingTimeout</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=140</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=142" BrowseName="GenerateFileForRead" ParentNodeId="ns=1;i=140" MethodDeclarationId="i=15746">
+    <DisplayName>GenerateFileForRead</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=143</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=144</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=140</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=143" BrowseName="InputArguments" ParentNodeId="ns=1;i=142" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=142</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>GenerateOptions</Name>
+              <DataType>
+                <Identifier>i=24</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=144" BrowseName="OutputArguments" ParentNodeId="ns=1;i=142" DataType="i=296" ValueRank="1" ArrayDimensions="3">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=142</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>CompletionStateMachine</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=145" BrowseName="GenerateFileForWrite" ParentNodeId="ns=1;i=140" MethodDeclarationId="i=15749">
+    <DisplayName>GenerateFileForWrite</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=146</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=147</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=140</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=146" BrowseName="InputArguments" ParentNodeId="ns=1;i=145" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=145</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>GenerateOptions</Name>
+              <DataType>
+                <Identifier>i=24</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=147" BrowseName="OutputArguments" ParentNodeId="ns=1;i=145" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=145</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=148" BrowseName="CloseAndCommit" ParentNodeId="ns=1;i=140" MethodDeclarationId="i=15751">
+    <DisplayName>CloseAndCommit</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=149</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=150</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=140</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=149" BrowseName="InputArguments" ParentNodeId="ns=1;i=148" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=148</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=150" BrowseName="OutputArguments" ParentNodeId="ns=1;i=148" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=148</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>CompletionStateMachine</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=151" BrowseName="1:ErrorMessage" ParentNodeId="ns=1;i=137" DataType="LocalizedText">
+    <DisplayName>ErrorMessage</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=137</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=152" BrowseName="1:WriteBlockSize" ParentNodeId="ns=1;i=137" DataType="UInt32">
+    <DisplayName>WriteBlockSize</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=137</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=153" BrowseName="1:DirectLoadingType">
+    <DisplayName>DirectLoadingType</DisplayName>
+    <Category>DI SU DirectLoading</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.4/#8.4.4.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=169</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=170</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=137</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=169" BrowseName="1:UpdateBehavior" ParentNodeId="ns=1;i=153" DataType="ns=1;i=333">
+    <DisplayName>UpdateBehavior</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=153</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=170" BrowseName="1:WriteTimeout" ParentNodeId="ns=1;i=153" DataType="i=290">
+    <DisplayName>WriteTimeout</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=153</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=171" BrowseName="1:CachedLoadingType">
+    <DisplayName>CachedLoadingType</DisplayName>
+    <Category>DI SU CachedLoading</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.5/#8.4.5.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=187</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=188</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=189</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=137</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=187" BrowseName="1:PendingVersion" ParentNodeId="ns=1;i=171">
+    <DisplayName>PendingVersion</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=366</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=367</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=368</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=212</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=171</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=366" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=187" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=187</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=367" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=187" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=187</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=368" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=187" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=187</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=188" BrowseName="1:FallbackVersion" ParentNodeId="ns=1;i=171">
+    <DisplayName>FallbackVersion</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=373</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=374</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=375</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=212</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=171</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=373" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=188" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=188</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=374" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=188" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=188</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=375" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=188" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=188</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=189" BrowseName="1:GetUpdateBehavior" ParentNodeId="ns=1;i=171">
+    <DisplayName>GetUpdateBehavior</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=190</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=191</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=171</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=190" BrowseName="InputArguments" ParentNodeId="ns=1;i=189" DataType="i=296" ValueRank="1" ArrayDimensions="3">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=189</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ManufacturerUri</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>SoftwareRevision</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>PatchIdentifiers</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>1</ValueRank>
+              <ArrayDimensions>
+                <UInt32>0</UInt32>
+              </ArrayDimensions>
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=191" BrowseName="OutputArguments" ParentNodeId="ns=1;i=189" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=189</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>UpdateBehavior</Name>
+              <DataType>
+                <Identifier>ns=1;i=333</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=192" BrowseName="1:FileSystemLoadingType">
+    <DisplayName>FileSystemLoadingType</DisplayName>
+    <Category>DI SU FileSystem Loading</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.6/#8.4.6.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=194</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=206</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=209</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=135</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=194" BrowseName="FileSystem" ParentNodeId="ns=1;i=192">
+    <DisplayName>FileSystem</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=195</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=198</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=201</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=203</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=13353</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=192</Reference>
+    </References>
+  </UAObject>
+  <UAMethod NodeId="ns=1;i=195" BrowseName="CreateDirectory" ParentNodeId="ns=1;i=194" MethodDeclarationId="i=13387">
+    <DisplayName>CreateDirectory</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=196</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=197</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=194</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=196" BrowseName="InputArguments" ParentNodeId="ns=1;i=195" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=195</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>DirectoryName</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=197" BrowseName="OutputArguments" ParentNodeId="ns=1;i=195" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=195</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>DirectoryNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=198" BrowseName="CreateFile" ParentNodeId="ns=1;i=194" MethodDeclarationId="i=13390">
+    <DisplayName>CreateFile</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=199</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=200</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=194</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=199" BrowseName="InputArguments" ParentNodeId="ns=1;i=198" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=198</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileName</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>RequestFileOpen</Name>
+              <DataType>
+                <Identifier>i=1</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=200" BrowseName="OutputArguments" ParentNodeId="ns=1;i=198" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=198</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>FileHandle</Name>
+              <DataType>
+                <Identifier>i=7</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=201" BrowseName="Delete" SymbolicName="DeleteFileSystemObject" ParentNodeId="ns=1;i=194" MethodDeclarationId="i=13393">
+    <DisplayName>Delete</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=202</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=194</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=202" BrowseName="InputArguments" ParentNodeId="ns=1;i=201" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=201</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ObjectToDelete</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=203" BrowseName="MoveOrCopy" ParentNodeId="ns=1;i=194" MethodDeclarationId="i=13395">
+    <DisplayName>MoveOrCopy</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=204</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=205</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=194</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=204" BrowseName="InputArguments" ParentNodeId="ns=1;i=203" DataType="i=296" ValueRank="1" ArrayDimensions="4">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=203</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ObjectToMoveOrCopy</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>TargetDirectory</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>CreateCopy</Name>
+              <DataType>
+                <Identifier>i=1</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>NewName</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=205" BrowseName="OutputArguments" ParentNodeId="ns=1;i=203" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=203</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>NewNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=206" BrowseName="1:GetUpdateBehavior" ParentNodeId="ns=1;i=192">
+    <DisplayName>GetUpdateBehavior</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=207</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=208</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=192</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=207" BrowseName="InputArguments" ParentNodeId="ns=1;i=206" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=206</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>NodeIds</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>1</ValueRank>
+              <ArrayDimensions>
+                <UInt32>0</UInt32>
+              </ArrayDimensions>
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=208" BrowseName="OutputArguments" ParentNodeId="ns=1;i=206" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=206</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>UpdateBehavior</Name>
+              <DataType>
+                <Identifier>ns=1;i=333</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=209" BrowseName="1:ValidateFiles" ParentNodeId="ns=1;i=192">
+    <DisplayName>ValidateFiles</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=210</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=211</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=192</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=210" BrowseName="InputArguments" ParentNodeId="ns=1;i=209" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=209</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>NodeIds</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>1</ValueRank>
+              <ArrayDimensions>
+                <UInt32>0</UInt32>
+              </ArrayDimensions>
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=211" BrowseName="OutputArguments" ParentNodeId="ns=1;i=209" DataType="i=296" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>OutputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=209</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ErrorCode</Name>
+              <DataType>
+                <Identifier>i=6</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ErrorMessage</Name>
+              <DataType>
+                <Identifier>i=21</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=212" BrowseName="1:SoftwareVersionType">
+    <DisplayName>SoftwareVersionType</DisplayName>
+    <Category>DI SU Software Update</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.7/#8.4.7.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=380</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=381</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=382</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=383</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=384</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=385</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=386</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=380" BrowseName="1:Manufacturer" ParentNodeId="ns=1;i=212" DataType="LocalizedText">
+    <DisplayName>Manufacturer</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=381" BrowseName="1:ManufacturerUri" ParentNodeId="ns=1;i=212" DataType="String">
+    <DisplayName>ManufacturerUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=382" BrowseName="1:SoftwareRevision" ParentNodeId="ns=1;i=212" DataType="String">
+    <DisplayName>SoftwareRevision</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=383" BrowseName="1:PatchIdentifiers" ParentNodeId="ns=1;i=212" DataType="String" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>PatchIdentifiers</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=384" BrowseName="1:ReleaseDate" ParentNodeId="ns=1;i=212" DataType="DateTime">
+    <DisplayName>ReleaseDate</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=385" BrowseName="1:ChangeLogReference" ParentNodeId="ns=1;i=212" DataType="String">
+    <DisplayName>ChangeLogReference</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=386" BrowseName="1:Hash" ParentNodeId="ns=1;i=212" DataType="ByteString">
+    <DisplayName>Hash</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=212</Reference>
+    </References>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=213" BrowseName="1:PrepareForUpdateStateMachineType">
+    <DisplayName>PrepareForUpdateStateMachineType</DisplayName>
+    <Category>DI SU PrepareForUpdate</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.8/#8.4.8.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=227</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=228</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=229</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=230</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=231</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=233</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=235</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=237</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=239</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=241</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=243</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=245</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=247</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=2771</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=227" BrowseName="1:PercentComplete" ParentNodeId="ns=1;i=213" DataType="Byte">
+    <DisplayName>PercentComplete</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=228" BrowseName="1:Prepare" ParentNodeId="ns=1;i=213">
+    <DisplayName>Prepare</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAMethod>
+  <UAMethod NodeId="ns=1;i=229" BrowseName="1:Abort" ParentNodeId="ns=1;i=213">
+    <DisplayName>Abort</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAMethod>
+  <UAMethod NodeId="ns=1;i=230" BrowseName="1:Resume" ParentNodeId="ns=1;i=213">
+    <DisplayName>Resume</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAMethod>
+  <UAObject NodeId="ns=1;i=231" BrowseName="1:Idle" ParentNodeId="ns=1;i=213">
+    <DisplayName>Idle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=232</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=239</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=241</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=247</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2309</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=232" BrowseName="StateNumber" ParentNodeId="ns=1;i=231" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=231</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=233" BrowseName="1:Preparing" ParentNodeId="ns=1;i=213">
+    <DisplayName>Preparing</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=234</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=239</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=241</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=243</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=234" BrowseName="StateNumber" ParentNodeId="ns=1;i=233" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=233</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=235" BrowseName="1:PreparedForUpdate" ParentNodeId="ns=1;i=213">
+    <DisplayName>PreparedForUpdate</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=236</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=243</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=245</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=236" BrowseName="StateNumber" ParentNodeId="ns=1;i=235" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=235</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">3</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=237" BrowseName="1:Resuming" ParentNodeId="ns=1;i=213">
+    <DisplayName>Resuming</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=238</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=245</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=247</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=238" BrowseName="StateNumber" ParentNodeId="ns=1;i=237" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=237</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">4</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=239" BrowseName="1:IdleToPreparing" ParentNodeId="ns=1;i=213">
+    <DisplayName>IdleToPreparing</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=240</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=231</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=233</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=240" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=239" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=239</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">12</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=241" BrowseName="1:PreparingToIdle" ParentNodeId="ns=1;i=213">
+    <DisplayName>PreparingToIdle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=242</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=233</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=231</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=242" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=241" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=241</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">21</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=243" BrowseName="1:PreparingToPreparedForUpdate" ParentNodeId="ns=1;i=213">
+    <DisplayName>PreparingToPreparedForUpdate</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=244</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=233</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=235</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=244" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=243" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=243</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">23</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=245" BrowseName="1:PreparedForUpdateToResuming" ParentNodeId="ns=1;i=213">
+    <DisplayName>PreparedForUpdateToResuming</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=246</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=235</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=237</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=246" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=245" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=245</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">34</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=247" BrowseName="1:ResumingToIdle" ParentNodeId="ns=1;i=213">
+    <DisplayName>ResumingToIdle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=248</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=237</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=231</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=213</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=248" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=247" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=247</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">41</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=249" BrowseName="1:InstallationStateMachineType">
+    <DisplayName>InstallationStateMachineType</DisplayName>
+    <Category>DI SU Software Update</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.9/#8.4.9.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=263</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=264</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=265</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=268</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=270</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=271</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=273</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=275</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=277</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=279</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=281</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=283</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=2771</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=263" BrowseName="1:PercentComplete" ParentNodeId="ns=1;i=249" DataType="Byte">
+    <DisplayName>PercentComplete</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=264" BrowseName="1:InstallationDelay" ParentNodeId="ns=1;i=249" DataType="i=290">
+    <DisplayName>InstallationDelay</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=265" BrowseName="1:InstallSoftwarePackage" ParentNodeId="ns=1;i=249">
+    <DisplayName>InstallSoftwarePackage</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=266</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=266" BrowseName="InputArguments" ParentNodeId="ns=1;i=265" DataType="i=296" ValueRank="1" ArrayDimensions="4">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=265</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>ManufacturerUri</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>SoftwareRevision</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>PatchIdentifiers</Name>
+              <DataType>
+                <Identifier>i=12</Identifier>
+              </DataType>
+              <ValueRank>1</ValueRank>
+              <ArrayDimensions>
+                <UInt32>0</UInt32>
+              </ArrayDimensions>
+            </Argument>
+          </Body>
+        </ExtensionObject>
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>Hash</Name>
+              <DataType>
+                <Identifier>i=15</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=268" BrowseName="1:InstallFiles" ParentNodeId="ns=1;i=249">
+    <DisplayName>InstallFiles</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=269</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=269" BrowseName="InputArguments" ParentNodeId="ns=1;i=268" DataType="i=296" ValueRank="1" ArrayDimensions="1">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=268</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>NodeIds</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>1</ValueRank>
+              <ArrayDimensions>
+                <UInt32>0</UInt32>
+              </ArrayDimensions>
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="ns=1;i=270" BrowseName="1:Resume" ParentNodeId="ns=1;i=249">
+    <DisplayName>Resume</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAMethod>
+  <UAObject NodeId="ns=1;i=271" BrowseName="1:Idle" ParentNodeId="ns=1;i=249">
+    <DisplayName>Idle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=272</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=277</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=279</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=283</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2309</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=272" BrowseName="StateNumber" ParentNodeId="ns=1;i=271" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=271</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=273" BrowseName="1:Installing" ParentNodeId="ns=1;i=249">
+    <DisplayName>Installing</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=274</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=277</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=279</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=281</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=274" BrowseName="StateNumber" ParentNodeId="ns=1;i=273" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=273</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=275" BrowseName="1:Error" ParentNodeId="ns=1;i=249">
+    <DisplayName>Error</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=276</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=281</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=283</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=276" BrowseName="StateNumber" ParentNodeId="ns=1;i=275" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=275</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">3</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=277" BrowseName="1:IdleToInstalling" ParentNodeId="ns=1;i=249">
+    <DisplayName>IdleToInstalling</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=387</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=271</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=273</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=387" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=277" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=277</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">12</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=279" BrowseName="1:InstallingToIdle" ParentNodeId="ns=1;i=249">
+    <DisplayName>InstallingToIdle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=280</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=273</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=271</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=280" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=279" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=279</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">21</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=281" BrowseName="1:InstallingToError" ParentNodeId="ns=1;i=249">
+    <DisplayName>InstallingToError</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=282</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=273</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=275</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=282" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=281" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=281</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">23</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=283" BrowseName="1:ErrorToIdle" ParentNodeId="ns=1;i=249">
+    <DisplayName>ErrorToIdle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=284</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=275</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=271</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=249</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=284" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=283" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=283</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">31</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=285" BrowseName="1:PowerCycleStateMachineType">
+    <DisplayName>PowerCycleStateMachineType</DisplayName>
+    <Category>DI SU Manual Power Cycle</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.10</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=299</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=301</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=303</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=305</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=2771</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=299" BrowseName="1:NotWaitingForPowerCycle" ParentNodeId="ns=1;i=285">
+    <DisplayName>NotWaitingForPowerCycle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=300</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=303</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=305</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2309</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=285</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=300" BrowseName="StateNumber" ParentNodeId="ns=1;i=299" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=299</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=301" BrowseName="1:WaitingForPowerCycle" ParentNodeId="ns=1;i=285">
+    <DisplayName>WaitingForPowerCycle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=302</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=303</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=305</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=285</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=302" BrowseName="StateNumber" ParentNodeId="ns=1;i=301" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=301</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=303" BrowseName="1:NotWaitingForPowerCycleToWaitingForPowerCycle" ParentNodeId="ns=1;i=285">
+    <DisplayName>NotWaitingForPowerCycleToWaitingForPowerCycle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=304</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=299</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=301</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=285</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=304" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=303" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=303</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">12</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=305" BrowseName="1:WaitingForPowerCycleToNotWaitingForPowerCycle" ParentNodeId="ns=1;i=285">
+    <DisplayName>WaitingForPowerCycleToNotWaitingForPowerCycle</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=306</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=301</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=299</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=285</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=306" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=305" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=305</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">21</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObjectType NodeId="ns=1;i=307" BrowseName="1:ConfirmationStateMachineType">
+    <DisplayName>ConfirmationStateMachineType</DisplayName>
+    <Category>DI SU Update Confirmation</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.4.11/#8.4.11.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasComponent">ns=1;i=321</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=322</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=323</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=325</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=327</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=329</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=2771</Reference>
+    </References>
+  </UAObjectType>
+  <UAMethod NodeId="ns=1;i=321" BrowseName="1:Confirm" ParentNodeId="ns=1;i=307">
+    <DisplayName>Confirm</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=307</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="ns=1;i=322" BrowseName="1:ConfirmationTimeout" ParentNodeId="ns=1;i=307" DataType="i=290">
+    <DisplayName>ConfirmationTimeout</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=307</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=323" BrowseName="1:NotWaitingForConfirm" ParentNodeId="ns=1;i=307">
+    <DisplayName>NotWaitingForConfirm</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=324</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=327</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=329</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2309</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=307</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=324" BrowseName="StateNumber" ParentNodeId="ns=1;i=323" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=323</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=325" BrowseName="1:WaitingForConfirm" ParentNodeId="ns=1;i=307">
+    <DisplayName>WaitingForConfirm</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=326</Reference>
+      <Reference ReferenceType="ToState" IsForward="false">ns=1;i=327</Reference>
+      <Reference ReferenceType="FromState" IsForward="false">ns=1;i=329</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2307</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=307</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=326" BrowseName="StateNumber" ParentNodeId="ns=1;i=325" DataType="UInt32">
+    <DisplayName>StateNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=325</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">2</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=327" BrowseName="1:NotWaitingForConfirmToWaitingForConfirm" ParentNodeId="ns=1;i=307">
+    <DisplayName>NotWaitingForConfirmToWaitingForConfirm</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=328</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=323</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=325</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=307</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=328" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=327" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=327</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">12</UInt32>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=329" BrowseName="1:WaitingForConfirmToNotWaitingForConfirm" ParentNodeId="ns=1;i=307">
+    <DisplayName>WaitingForConfirmToNotWaitingForConfirm</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=330</Reference>
+      <Reference ReferenceType="FromState">ns=1;i=325</Reference>
+      <Reference ReferenceType="ToState">ns=1;i=323</Reference>
+      <Reference ReferenceType="HasEffect">i=2311</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2310</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=307</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=330" BrowseName="TransitionNumber" ParentNodeId="ns=1;i=329" DataType="UInt32">
+    <DisplayName>TransitionNumber</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=329</Reference>
+    </References>
+    <Value>
+      <UInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">21</UInt32>
+    </Value>
+  </UAVariable>
+  <UADataType NodeId="ns=1;i=331" BrowseName="1:SoftwareVersionFileType">
+    <DisplayName>SoftwareVersionFileType</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.5.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=332</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=29</Reference>
+    </References>
+    <Definition Name="1:SoftwareVersionFileType">
+      <Field Name="Current" Value="0">
+        <Description>The currently used version of the software identified by the CurrentVersion Object.</Description>
+      </Field>
+      <Field Name="Pending" Value="1">
+        <Description>The pending version of the software that could be installed identified by the PendingVersion Object.</Description>
+      </Field>
+      <Field Name="Fallback" Value="2">
+        <Description>The fallback version of the software identified by the FallbackVersion Object.</Description>
+      </Field>
+    </Definition>
+  </UADataType>
+  <UAVariable NodeId="ns=1;i=332" BrowseName="EnumStrings" ParentNodeId="ns=1;i=331" DataType="LocalizedText" ValueRank="1" ArrayDimensions="3">
+    <DisplayName>EnumStrings</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=331</Reference>
+    </References>
+    <Value>
+      <ListOfLocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <LocalizedText>
+          <Text>Current</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>Pending</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>Fallback</Text>
+        </LocalizedText>
+      </ListOfLocalizedText>
+    </Value>
+  </UAVariable>
+  <UADataType NodeId="ns=1;i=333" BrowseName="1:UpdateBehavior">
+    <DisplayName>UpdateBehavior</DisplayName>
+    <Category>DI SU Software Update</Category>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/8.5.2</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=388</Reference>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=7</Reference>
+    </References>
+    <Definition Name="1:UpdateBehavior" IsOptionSet="true">
+      <Field Name="KeepsParameters" Value="0">
+        <Description>If KeepsParameters is not set, the device will lose its configuration during update. The Client should do a backup of the parameters before the update and restore them afterwards.</Description>
+      </Field>
+      <Field Name="WillDisconnect" Value="1">
+        <Description>If WillDisconnect is set, the OPC UA Server will restart during installation. This can be the case if the update is about the firmware of the device that hosts the OPC UA Server.</Description>
+      </Field>
+      <Field Name="RequiresPowerCycle" Value="2">
+        <Description>If RequiresPowerCycle is set, the devices require a manual power off / power on for installation.</Description>
+      </Field>
+      <Field Name="WillReboot" Value="3">
+        <Description>If WillReboot is set, the device will reboot during the update, inclusive of embedded infrastructure elements like an integrated switch. An update Client should take this into account since the devices behind an integrated switch are not reachable for that time.</Description>
+      </Field>
+      <Field Name="NeedsPreparation" Value="4">
+        <Description>If NeedsPreparation is not set, the Client can install the update without maintaining the PrepareForUpdateStateMachine. This can be used to support an installation without stopping the software.</Description>
+      </Field>
+    </Definition>
+  </UADataType>
+  <UAVariable NodeId="ns=1;i=388" BrowseName="OptionSetValues" ParentNodeId="ns=1;i=333" DataType="LocalizedText" ValueRank="1" ArrayDimensions="5">
+    <DisplayName>OptionSetValues</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=333</Reference>
+    </References>
+    <Value>
+      <ListOfLocalizedText xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <LocalizedText>
+          <Text>KeepsParameters</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>WillDisconnect</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>RequiresPowerCycle</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>WillReboot</Text>
+        </LocalizedText>
+        <LocalizedText>
+          <Text>NeedsPreparation</Text>
+        </LocalizedText>
+      </ListOfLocalizedText>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=6551" BrowseName="Default Binary" SymbolicName="DefaultBinary">
+    <DisplayName>Default Binary</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=6522</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=6555</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15891" BrowseName="Default Binary" SymbolicName="DefaultBinary">
+    <DisplayName>Default Binary</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15888</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=15894</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15892" BrowseName="Default Binary" SymbolicName="DefaultBinary">
+    <DisplayName>Default Binary</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15889</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=15897</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6554" BrowseName="Default Binary" SymbolicName="DefaultBinary">
+    <DisplayName>Default Binary</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=6525</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=6564</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6435" BrowseName="1:Opc.Ua.Di" SymbolicName="OpcUaDi_BinarySchema" ReleaseStatus="Deprecated" DataType="ByteString">
+    <DisplayName>Opc.Ua.Di</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6437</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15893</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6555</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15894</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15897</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6564</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=93</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=72</Reference>
+    </References>
+    <Value>
+      <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">PG9wYzpUeXBlRGljdGlvbmFyeQ0KICB4bWxuczpvcGM9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9y
+Zy9CaW5hcnlTY2hlbWEvIg0KICB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1M
+U2NoZW1hLWluc3RhbmNlIg0KICB4bWxuczp1YT0iaHR0cDovL29wY2ZvdW5kYXRpb24ub3JnL1VB
+LyINCiAgeG1sbnM6dG5zPSJodHRwOi8vb3BjZm91bmRhdGlvbi5vcmcvVUEvREkvIg0KICBEZWZh
+dWx0Qnl0ZU9yZGVyPSJMaXR0bGVFbmRpYW4iDQogIFRhcmdldE5hbWVzcGFjZT0iaHR0cDovL29w
+Y2ZvdW5kYXRpb24ub3JnL1VBL0RJLyINCj4NCiAgPG9wYzpJbXBvcnQgTmFtZXNwYWNlPSJodHRw
+Oi8vb3BjZm91bmRhdGlvbi5vcmcvVUEvIiBMb2NhdGlvbj0iT3BjLlVhLkJpbmFyeVNjaGVtYS5i
+c2QiLz4NCg0KICA8b3BjOkVudW1lcmF0ZWRUeXBlIE5hbWU9IkRldmljZUhlYWx0aEVudW1lcmF0
+aW9uIiBMZW5ndGhJbkJpdHM9IjMyIj4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1ZSBOYW1lPSJO
+T1JNQUwiIFZhbHVlPSIwIiAvPg0KICAgIDxvcGM6RW51bWVyYXRlZFZhbHVlIE5hbWU9IkZBSUxV
+UkUiIFZhbHVlPSIxIiAvPg0KICAgIDxvcGM6RW51bWVyYXRlZFZhbHVlIE5hbWU9IkNIRUNLX0ZV
+TkNUSU9OIiBWYWx1ZT0iMiIgLz4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1ZSBOYW1lPSJPRkZf
+U1BFQyIgVmFsdWU9IjMiIC8+DQogICAgPG9wYzpFbnVtZXJhdGVkVmFsdWUgTmFtZT0iTUFJTlRF
+TkFOQ0VfUkVRVUlSRUQiIFZhbHVlPSI0IiAvPg0KICA8L29wYzpFbnVtZXJhdGVkVHlwZT4NCg0K
+ICA8b3BjOlN0cnVjdHVyZWRUeXBlIE5hbWU9IkZldGNoUmVzdWx0RGF0YVR5cGUiIEJhc2VUeXBl
+PSJ1YTpFeHRlbnNpb25PYmplY3QiPg0KICA8L29wYzpTdHJ1Y3R1cmVkVHlwZT4NCg0KICA8b3Bj
+OlN0cnVjdHVyZWRUeXBlIE5hbWU9IlRyYW5zZmVyUmVzdWx0RXJyb3JEYXRhVHlwZSIgQmFzZVR5
+cGU9InRuczpGZXRjaFJlc3VsdERhdGFUeXBlIj4NCiAgICA8b3BjOkZpZWxkIE5hbWU9IlN0YXR1
+cyIgVHlwZU5hbWU9Im9wYzpJbnQzMiIgLz4NCiAgICA8b3BjOkZpZWxkIE5hbWU9IkRpYWdub3N0
+aWNzIiBUeXBlTmFtZT0idWE6RGlhZ25vc3RpY0luZm8iIC8+DQogIDwvb3BjOlN0cnVjdHVyZWRU
+eXBlPg0KDQogIDxvcGM6U3RydWN0dXJlZFR5cGUgTmFtZT0iVHJhbnNmZXJSZXN1bHREYXRhRGF0
+YVR5cGUiIEJhc2VUeXBlPSJ0bnM6RmV0Y2hSZXN1bHREYXRhVHlwZSI+DQogICAgPG9wYzpGaWVs
+ZCBOYW1lPSJTZXF1ZW5jZU51bWJlciIgVHlwZU5hbWU9Im9wYzpJbnQzMiIgLz4NCiAgICA8b3Bj
+OkZpZWxkIE5hbWU9IkVuZE9mUmVzdWx0cyIgVHlwZU5hbWU9Im9wYzpCb29sZWFuIiAvPg0KICAg
+IDxvcGM6RmllbGQgTmFtZT0iTm9PZlBhcmFtZXRlckRlZnMiIFR5cGVOYW1lPSJvcGM6SW50MzIi
+IC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJQYXJhbWV0ZXJEZWZzIiBUeXBlTmFtZT0idG5zOlBh
+cmFtZXRlclJlc3VsdERhdGFUeXBlIiBMZW5ndGhGaWVsZD0iTm9PZlBhcmFtZXRlckRlZnMiIC8+
+DQogIDwvb3BjOlN0cnVjdHVyZWRUeXBlPg0KDQogIDxvcGM6U3RydWN0dXJlZFR5cGUgTmFtZT0i
+UGFyYW1ldGVyUmVzdWx0RGF0YVR5cGUiIEJhc2VUeXBlPSJ1YTpFeHRlbnNpb25PYmplY3QiPg0K
+ICAgIDxvcGM6RmllbGQgTmFtZT0iTm9PZk5vZGVQYXRoIiBUeXBlTmFtZT0ib3BjOkludDMyIiAv
+Pg0KICAgIDxvcGM6RmllbGQgTmFtZT0iTm9kZVBhdGgiIFR5cGVOYW1lPSJ1YTpRdWFsaWZpZWRO
+YW1lIiBMZW5ndGhGaWVsZD0iTm9PZk5vZGVQYXRoIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0i
+U3RhdHVzQ29kZSIgVHlwZU5hbWU9InVhOlN0YXR1c0NvZGUiIC8+DQogICAgPG9wYzpGaWVsZCBO
+YW1lPSJEaWFnbm9zdGljcyIgVHlwZU5hbWU9InVhOkRpYWdub3N0aWNJbmZvIiAvPg0KICA8L29w
+YzpTdHJ1Y3R1cmVkVHlwZT4NCg0KICA8b3BjOkVudW1lcmF0ZWRUeXBlIE5hbWU9IlNvZnR3YXJl
+VmVyc2lvbkZpbGVUeXBlIiBMZW5ndGhJbkJpdHM9IjMyIj4NCiAgICA8b3BjOkVudW1lcmF0ZWRW
+YWx1ZSBOYW1lPSJDdXJyZW50IiBWYWx1ZT0iMCIgLz4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1
+ZSBOYW1lPSJQZW5kaW5nIiBWYWx1ZT0iMSIgLz4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1ZSBO
+YW1lPSJGYWxsYmFjayIgVmFsdWU9IjIiIC8+DQogIDwvb3BjOkVudW1lcmF0ZWRUeXBlPg0KDQog
+IDxvcGM6RW51bWVyYXRlZFR5cGUgTmFtZT0iVXBkYXRlQmVoYXZpb3IiIExlbmd0aEluQml0cz0i
+MzIiIElzT3B0aW9uU2V0PSJ0cnVlIj4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1ZSBOYW1lPSJO
+b25lIiBWYWx1ZT0iMCIgLz4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1ZSBOYW1lPSJLZWVwc1Bh
+cmFtZXRlcnMiIFZhbHVlPSIxIiAvPg0KICAgIDxvcGM6RW51bWVyYXRlZFZhbHVlIE5hbWU9Ildp
+bGxEaXNjb25uZWN0IiBWYWx1ZT0iMiIgLz4NCiAgICA8b3BjOkVudW1lcmF0ZWRWYWx1ZSBOYW1l
+PSJSZXF1aXJlc1Bvd2VyQ3ljbGUiIFZhbHVlPSI0IiAvPg0KICAgIDxvcGM6RW51bWVyYXRlZFZh
+bHVlIE5hbWU9IldpbGxSZWJvb3QiIFZhbHVlPSI4IiAvPg0KICAgIDxvcGM6RW51bWVyYXRlZFZh
+bHVlIE5hbWU9Ik5lZWRzUHJlcGFyYXRpb24iIFZhbHVlPSIxNiIgLz4NCiAgPC9vcGM6RW51bWVy
+YXRlZFR5cGU+DQoNCjwvb3BjOlR5cGVEaWN0aW9uYXJ5Pg==</ByteString>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6437" BrowseName="NamespaceUri" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6435" DataType="String">
+    <DisplayName>NamespaceUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6435</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/DI/</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15893" BrowseName="Deprecated" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6435" DataType="Boolean">
+    <DisplayName>Deprecated</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6435</Reference>
+    </References>
+    <Value>
+      <Boolean xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">true</Boolean>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6555" BrowseName="1:FetchResultDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6435" DataType="String">
+    <DisplayName>FetchResultDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6435</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">FetchResultDataType</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15894" BrowseName="1:TransferResultErrorDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6435" DataType="String">
+    <DisplayName>TransferResultErrorDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6435</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">TransferResultErrorDataType</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15897" BrowseName="1:TransferResultDataDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6435" DataType="String">
+    <DisplayName>TransferResultDataDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6435</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">TransferResultDataDataType</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6564" BrowseName="1:ParameterResultDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6435" DataType="String">
+    <DisplayName>ParameterResultDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6435</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">ParameterResultDataType</String>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=6535" BrowseName="Default XML" SymbolicName="DefaultXml">
+    <DisplayName>Default XML</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=6522</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=6539</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15900" BrowseName="Default XML" SymbolicName="DefaultXml">
+    <DisplayName>Default XML</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15888</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=15903</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15901" BrowseName="Default XML" SymbolicName="DefaultXml">
+    <DisplayName>Default XML</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15889</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=15906</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=6538" BrowseName="Default XML" SymbolicName="DefaultXml">
+    <DisplayName>Default XML</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=6525</Reference>
+      <Reference ReferenceType="HasDescription">ns=1;i=6548</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=6423" BrowseName="1:Opc.Ua.Di" SymbolicName="OpcUaDi_XmlSchema" ReleaseStatus="Deprecated" DataType="ByteString">
+    <DisplayName>Opc.Ua.Di</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=6425</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15902</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6539</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15903</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=15906</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6548</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=92</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=72</Reference>
+    </References>
+    <Value>
+      <ByteString xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">PHhzOnNjaGVtYQ0KICB4bWxuczp4cz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEi
+DQogIHhtbG5zOnVhPSJodHRwOi8vb3BjZm91bmRhdGlvbi5vcmcvVUEvMjAwOC8wMi9UeXBlcy54
+c2QiDQogIHhtbG5zOnRucz0iaHR0cDovL29wY2ZvdW5kYXRpb24ub3JnL1VBL0RJL1R5cGVzLnhz
+ZCINCiAgdGFyZ2V0TmFtZXNwYWNlPSJodHRwOi8vb3BjZm91bmRhdGlvbi5vcmcvVUEvREkvVHlw
+ZXMueHNkIg0KICBlbGVtZW50Rm9ybURlZmF1bHQ9InF1YWxpZmllZCINCj4NCiAgPHhzOmltcG9y
+dCBuYW1lc3BhY2U9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9VQS8yMDA4LzAyL1R5cGVzLnhz
+ZCIgLz4NCg0KICA8eHM6c2ltcGxlVHlwZSAgbmFtZT0iRGV2aWNlSGVhbHRoRW51bWVyYXRpb24i
+Pg0KICAgIDx4czpyZXN0cmljdGlvbiBiYXNlPSJ4czpzdHJpbmciPg0KICAgICAgPHhzOmVudW1l
+cmF0aW9uIHZhbHVlPSJOT1JNQUxfMCIgLz4NCiAgICAgIDx4czplbnVtZXJhdGlvbiB2YWx1ZT0i
+RkFJTFVSRV8xIiAvPg0KICAgICAgPHhzOmVudW1lcmF0aW9uIHZhbHVlPSJDSEVDS19GVU5DVElP
+Tl8yIiAvPg0KICAgICAgPHhzOmVudW1lcmF0aW9uIHZhbHVlPSJPRkZfU1BFQ18zIiAvPg0KICAg
+ICAgPHhzOmVudW1lcmF0aW9uIHZhbHVlPSJNQUlOVEVOQU5DRV9SRVFVSVJFRF80IiAvPg0KICAg
+IDwveHM6cmVzdHJpY3Rpb24+DQogIDwveHM6c2ltcGxlVHlwZT4NCiAgPHhzOmVsZW1lbnQgbmFt
+ZT0iRGV2aWNlSGVhbHRoRW51bWVyYXRpb24iIHR5cGU9InRuczpEZXZpY2VIZWFsdGhFbnVtZXJh
+dGlvbiIgLz4NCg0KICA8eHM6Y29tcGxleFR5cGUgbmFtZT0iTGlzdE9mRGV2aWNlSGVhbHRoRW51
+bWVyYXRpb24iPg0KICAgIDx4czpzZXF1ZW5jZT4NCiAgICAgIDx4czplbGVtZW50IG5hbWU9IkRl
+dmljZUhlYWx0aEVudW1lcmF0aW9uIiB0eXBlPSJ0bnM6RGV2aWNlSGVhbHRoRW51bWVyYXRpb24i
+IG1pbk9jY3Vycz0iMCIgbWF4T2NjdXJzPSJ1bmJvdW5kZWQiIC8+DQogICAgPC94czpzZXF1ZW5j
+ZT4NCiAgPC94czpjb21wbGV4VHlwZT4NCiAgPHhzOmVsZW1lbnQgbmFtZT0iTGlzdE9mRGV2aWNl
+SGVhbHRoRW51bWVyYXRpb24iIHR5cGU9InRuczpMaXN0T2ZEZXZpY2VIZWFsdGhFbnVtZXJhdGlv
+biIgbmlsbGFibGU9InRydWUiPjwveHM6ZWxlbWVudD4NCg0KICA8eHM6Y29tcGxleFR5cGUgbmFt
+ZT0iRmV0Y2hSZXN1bHREYXRhVHlwZSI+DQogICAgPHhzOnNlcXVlbmNlPg0KICAgIDwveHM6c2Vx
+dWVuY2U+DQogIDwveHM6Y29tcGxleFR5cGU+DQogIDx4czplbGVtZW50IG5hbWU9IkZldGNoUmVz
+dWx0RGF0YVR5cGUiIHR5cGU9InRuczpGZXRjaFJlc3VsdERhdGFUeXBlIiAvPg0KDQogIDx4czpj
+b21wbGV4VHlwZSBuYW1lPSJMaXN0T2ZGZXRjaFJlc3VsdERhdGFUeXBlIj4NCiAgICA8eHM6c2Vx
+dWVuY2U+DQogICAgICA8eHM6ZWxlbWVudCBuYW1lPSJGZXRjaFJlc3VsdERhdGFUeXBlIiB0eXBl
+PSJ0bnM6RmV0Y2hSZXN1bHREYXRhVHlwZSIgbWluT2NjdXJzPSIwIiBtYXhPY2N1cnM9InVuYm91
+bmRlZCIgbmlsbGFibGU9InRydWUiIC8+DQogICAgPC94czpzZXF1ZW5jZT4NCiAgPC94czpjb21w
+bGV4VHlwZT4NCiAgPHhzOmVsZW1lbnQgbmFtZT0iTGlzdE9mRmV0Y2hSZXN1bHREYXRhVHlwZSIg
+dHlwZT0idG5zOkxpc3RPZkZldGNoUmVzdWx0RGF0YVR5cGUiIG5pbGxhYmxlPSJ0cnVlIj48L3hz
+OmVsZW1lbnQ+DQoNCiAgPHhzOmNvbXBsZXhUeXBlIG5hbWU9IlRyYW5zZmVyUmVzdWx0RXJyb3JE
+YXRhVHlwZSI+DQogICAgPHhzOmNvbXBsZXhDb250ZW50IG1peGVkPSJmYWxzZSI+DQogICAgICA8
+eHM6ZXh0ZW5zaW9uIGJhc2U9InRuczpGZXRjaFJlc3VsdERhdGFUeXBlIj4NCiAgICAgICAgPHhz
+OnNlcXVlbmNlPg0KICAgICAgICAgIDx4czplbGVtZW50IG5hbWU9IlN0YXR1cyIgdHlwZT0ieHM6
+aW50IiBtaW5PY2N1cnM9IjAiIC8+DQogICAgICAgICAgPHhzOmVsZW1lbnQgbmFtZT0iRGlhZ25v
+c3RpY3MiIHR5cGU9InVhOkRpYWdub3N0aWNJbmZvIiBtaW5PY2N1cnM9IjAiIG5pbGxhYmxlPSJ0
+cnVlIiAvPg0KICAgICAgICA8L3hzOnNlcXVlbmNlPg0KICAgICAgPC94czpleHRlbnNpb24+DQog
+ICAgPC94czpjb21wbGV4Q29udGVudD4NCiAgPC94czpjb21wbGV4VHlwZT4NCiAgPHhzOmVsZW1l
+bnQgbmFtZT0iVHJhbnNmZXJSZXN1bHRFcnJvckRhdGFUeXBlIiB0eXBlPSJ0bnM6VHJhbnNmZXJS
+ZXN1bHRFcnJvckRhdGFUeXBlIiAvPg0KDQogIDx4czpjb21wbGV4VHlwZSBuYW1lPSJMaXN0T2ZU
+cmFuc2ZlclJlc3VsdEVycm9yRGF0YVR5cGUiPg0KICAgIDx4czpzZXF1ZW5jZT4NCiAgICAgIDx4
+czplbGVtZW50IG5hbWU9IlRyYW5zZmVyUmVzdWx0RXJyb3JEYXRhVHlwZSIgdHlwZT0idG5zOlRy
+YW5zZmVyUmVzdWx0RXJyb3JEYXRhVHlwZSIgbWluT2NjdXJzPSIwIiBtYXhPY2N1cnM9InVuYm91
+bmRlZCIgbmlsbGFibGU9InRydWUiIC8+DQogICAgPC94czpzZXF1ZW5jZT4NCiAgPC94czpjb21w
+bGV4VHlwZT4NCiAgPHhzOmVsZW1lbnQgbmFtZT0iTGlzdE9mVHJhbnNmZXJSZXN1bHRFcnJvckRh
+dGFUeXBlIiB0eXBlPSJ0bnM6TGlzdE9mVHJhbnNmZXJSZXN1bHRFcnJvckRhdGFUeXBlIiBuaWxs
+YWJsZT0idHJ1ZSI+PC94czplbGVtZW50Pg0KDQogIDx4czpjb21wbGV4VHlwZSBuYW1lPSJUcmFu
+c2ZlclJlc3VsdERhdGFEYXRhVHlwZSI+DQogICAgPHhzOmNvbXBsZXhDb250ZW50IG1peGVkPSJm
+YWxzZSI+DQogICAgICA8eHM6ZXh0ZW5zaW9uIGJhc2U9InRuczpGZXRjaFJlc3VsdERhdGFUeXBl
+Ij4NCiAgICAgICAgPHhzOnNlcXVlbmNlPg0KICAgICAgICAgIDx4czplbGVtZW50IG5hbWU9IlNl
+cXVlbmNlTnVtYmVyIiB0eXBlPSJ4czppbnQiIG1pbk9jY3Vycz0iMCIgLz4NCiAgICAgICAgICA8
+eHM6ZWxlbWVudCBuYW1lPSJFbmRPZlJlc3VsdHMiIHR5cGU9InhzOmJvb2xlYW4iIG1pbk9jY3Vy
+cz0iMCIgLz4NCiAgICAgICAgICA8eHM6ZWxlbWVudCBuYW1lPSJQYXJhbWV0ZXJEZWZzIiB0eXBl
+PSJ0bnM6TGlzdE9mUGFyYW1ldGVyUmVzdWx0RGF0YVR5cGUiIG1pbk9jY3Vycz0iMCIgbmlsbGFi
+bGU9InRydWUiIC8+DQogICAgICAgIDwveHM6c2VxdWVuY2U+DQogICAgICA8L3hzOmV4dGVuc2lv
+bj4NCiAgICA8L3hzOmNvbXBsZXhDb250ZW50Pg0KICA8L3hzOmNvbXBsZXhUeXBlPg0KICA8eHM6
+ZWxlbWVudCBuYW1lPSJUcmFuc2ZlclJlc3VsdERhdGFEYXRhVHlwZSIgdHlwZT0idG5zOlRyYW5z
+ZmVyUmVzdWx0RGF0YURhdGFUeXBlIiAvPg0KDQogIDx4czpjb21wbGV4VHlwZSBuYW1lPSJMaXN0
+T2ZUcmFuc2ZlclJlc3VsdERhdGFEYXRhVHlwZSI+DQogICAgPHhzOnNlcXVlbmNlPg0KICAgICAg
+PHhzOmVsZW1lbnQgbmFtZT0iVHJhbnNmZXJSZXN1bHREYXRhRGF0YVR5cGUiIHR5cGU9InRuczpU
+cmFuc2ZlclJlc3VsdERhdGFEYXRhVHlwZSIgbWluT2NjdXJzPSIwIiBtYXhPY2N1cnM9InVuYm91
+bmRlZCIgbmlsbGFibGU9InRydWUiIC8+DQogICAgPC94czpzZXF1ZW5jZT4NCiAgPC94czpjb21w
+bGV4VHlwZT4NCiAgPHhzOmVsZW1lbnQgbmFtZT0iTGlzdE9mVHJhbnNmZXJSZXN1bHREYXRhRGF0
+YVR5cGUiIHR5cGU9InRuczpMaXN0T2ZUcmFuc2ZlclJlc3VsdERhdGFEYXRhVHlwZSIgbmlsbGFi
+bGU9InRydWUiPjwveHM6ZWxlbWVudD4NCg0KICA8eHM6Y29tcGxleFR5cGUgbmFtZT0iUGFyYW1l
+dGVyUmVzdWx0RGF0YVR5cGUiPg0KICAgIDx4czpzZXF1ZW5jZT4NCiAgICAgIDx4czplbGVtZW50
+IG5hbWU9Ik5vZGVQYXRoIiB0eXBlPSJ1YTpMaXN0T2ZRdWFsaWZpZWROYW1lIiBtaW5PY2N1cnM9
+IjAiIG5pbGxhYmxlPSJ0cnVlIiAvPg0KICAgICAgPHhzOmVsZW1lbnQgbmFtZT0iU3RhdHVzQ29k
+ZSIgdHlwZT0idWE6U3RhdHVzQ29kZSIgbWluT2NjdXJzPSIwIiAvPg0KICAgICAgPHhzOmVsZW1l
+bnQgbmFtZT0iRGlhZ25vc3RpY3MiIHR5cGU9InVhOkRpYWdub3N0aWNJbmZvIiBtaW5PY2N1cnM9
+IjAiIG5pbGxhYmxlPSJ0cnVlIiAvPg0KICAgIDwveHM6c2VxdWVuY2U+DQogIDwveHM6Y29tcGxl
+eFR5cGU+DQogIDx4czplbGVtZW50IG5hbWU9IlBhcmFtZXRlclJlc3VsdERhdGFUeXBlIiB0eXBl
+PSJ0bnM6UGFyYW1ldGVyUmVzdWx0RGF0YVR5cGUiIC8+DQoNCiAgPHhzOmNvbXBsZXhUeXBlIG5h
+bWU9Ikxpc3RPZlBhcmFtZXRlclJlc3VsdERhdGFUeXBlIj4NCiAgICA8eHM6c2VxdWVuY2U+DQog
+ICAgICA8eHM6ZWxlbWVudCBuYW1lPSJQYXJhbWV0ZXJSZXN1bHREYXRhVHlwZSIgdHlwZT0idG5z
+OlBhcmFtZXRlclJlc3VsdERhdGFUeXBlIiBtaW5PY2N1cnM9IjAiIG1heE9jY3Vycz0idW5ib3Vu
+ZGVkIiBuaWxsYWJsZT0idHJ1ZSIgLz4NCiAgICA8L3hzOnNlcXVlbmNlPg0KICA8L3hzOmNvbXBs
+ZXhUeXBlPg0KICA8eHM6ZWxlbWVudCBuYW1lPSJMaXN0T2ZQYXJhbWV0ZXJSZXN1bHREYXRhVHlw
+ZSIgdHlwZT0idG5zOkxpc3RPZlBhcmFtZXRlclJlc3VsdERhdGFUeXBlIiBuaWxsYWJsZT0idHJ1
+ZSI+PC94czplbGVtZW50Pg0KDQogIDx4czpzaW1wbGVUeXBlICBuYW1lPSJTb2Z0d2FyZVZlcnNp
+b25GaWxlVHlwZSI+DQogICAgPHhzOnJlc3RyaWN0aW9uIGJhc2U9InhzOnN0cmluZyI+DQogICAg
+ICA8eHM6ZW51bWVyYXRpb24gdmFsdWU9IkN1cnJlbnRfMCIgLz4NCiAgICAgIDx4czplbnVtZXJh
+dGlvbiB2YWx1ZT0iUGVuZGluZ18xIiAvPg0KICAgICAgPHhzOmVudW1lcmF0aW9uIHZhbHVlPSJG
+YWxsYmFja18yIiAvPg0KICAgIDwveHM6cmVzdHJpY3Rpb24+DQogIDwveHM6c2ltcGxlVHlwZT4N
+CiAgPHhzOmVsZW1lbnQgbmFtZT0iU29mdHdhcmVWZXJzaW9uRmlsZVR5cGUiIHR5cGU9InRuczpT
+b2Z0d2FyZVZlcnNpb25GaWxlVHlwZSIgLz4NCg0KICA8eHM6Y29tcGxleFR5cGUgbmFtZT0iTGlz
+dE9mU29mdHdhcmVWZXJzaW9uRmlsZVR5cGUiPg0KICAgIDx4czpzZXF1ZW5jZT4NCiAgICAgIDx4
+czplbGVtZW50IG5hbWU9IlNvZnR3YXJlVmVyc2lvbkZpbGVUeXBlIiB0eXBlPSJ0bnM6U29mdHdh
+cmVWZXJzaW9uRmlsZVR5cGUiIG1pbk9jY3Vycz0iMCIgbWF4T2NjdXJzPSJ1bmJvdW5kZWQiIC8+
+DQogICAgPC94czpzZXF1ZW5jZT4NCiAgPC94czpjb21wbGV4VHlwZT4NCiAgPHhzOmVsZW1lbnQg
+bmFtZT0iTGlzdE9mU29mdHdhcmVWZXJzaW9uRmlsZVR5cGUiIHR5cGU9InRuczpMaXN0T2ZTb2Z0
+d2FyZVZlcnNpb25GaWxlVHlwZSIgbmlsbGFibGU9InRydWUiPjwveHM6ZWxlbWVudD4NCg0KICA8
+eHM6c2ltcGxlVHlwZSAgbmFtZT0iVXBkYXRlQmVoYXZpb3IiPg0KICAgIDx4czpyZXN0cmljdGlv
+biBiYXNlPSJ4czp1bnNpZ25lZEludCI+DQogICAgPC94czpyZXN0cmljdGlvbj4NCiAgPC94czpz
+aW1wbGVUeXBlPg0KICA8eHM6ZWxlbWVudCBuYW1lPSJVcGRhdGVCZWhhdmlvciIgdHlwZT0idG5z
+OlVwZGF0ZUJlaGF2aW9yIiAvPg0KDQogIDx4czpjb21wbGV4VHlwZSBuYW1lPSJMaXN0T2ZVcGRh
+dGVCZWhhdmlvciI+DQogICAgPHhzOnNlcXVlbmNlPg0KICAgICAgPHhzOmVsZW1lbnQgbmFtZT0i
+VXBkYXRlQmVoYXZpb3IiIHR5cGU9InRuczpVcGRhdGVCZWhhdmlvciIgbWluT2NjdXJzPSIwIiBt
+YXhPY2N1cnM9InVuYm91bmRlZCIgLz4NCiAgICA8L3hzOnNlcXVlbmNlPg0KICA8L3hzOmNvbXBs
+ZXhUeXBlPg0KICA8eHM6ZWxlbWVudCBuYW1lPSJMaXN0T2ZVcGRhdGVCZWhhdmlvciIgdHlwZT0i
+dG5zOkxpc3RPZlVwZGF0ZUJlaGF2aW9yIiBuaWxsYWJsZT0idHJ1ZSI+PC94czplbGVtZW50Pg0K
+DQo8L3hzOnNjaGVtYT4=</ByteString>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6425" BrowseName="NamespaceUri" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6423" DataType="String">
+    <DisplayName>NamespaceUri</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6423</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">http://opcfoundation.org/UA/DI/Types.xsd</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15902" BrowseName="Deprecated" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6423" DataType="Boolean">
+    <DisplayName>Deprecated</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=6423</Reference>
+    </References>
+    <Value>
+      <Boolean xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">true</Boolean>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6539" BrowseName="1:FetchResultDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6423" DataType="String">
+    <DisplayName>FetchResultDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6423</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">//xs:element[@name='FetchResultDataType']</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15903" BrowseName="1:TransferResultErrorDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6423" DataType="String">
+    <DisplayName>TransferResultErrorDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6423</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">//xs:element[@name='TransferResultErrorDataType']</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=15906" BrowseName="1:TransferResultDataDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6423" DataType="String">
+    <DisplayName>TransferResultDataDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6423</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">//xs:element[@name='TransferResultDataDataType']</String>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6548" BrowseName="1:ParameterResultDataType" ReleaseStatus="Deprecated" ParentNodeId="ns=1;i=6423" DataType="String">
+    <DisplayName>ParameterResultDataType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6423</Reference>
+    </References>
+    <Value>
+      <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">//xs:element[@name='ParameterResultDataType']</String>
+    </Value>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=15909" BrowseName="Default JSON" SymbolicName="DefaultJson">
+    <DisplayName>Default JSON</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=6522</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15910" BrowseName="Default JSON" SymbolicName="DefaultJson">
+    <DisplayName>Default JSON</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15888</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15911" BrowseName="Default JSON" SymbolicName="DefaultJson">
+    <DisplayName>Default JSON</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=15889</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15912" BrowseName="Default JSON" SymbolicName="DefaultJson">
+    <DisplayName>Default JSON</DisplayName>
+    <References>
+      <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=6525</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+    </References>
+  </UAObject>
+  <UAObject NodeId="ns=1;i=15001" BrowseName="1:http://opcfoundation.org/UA/DI/" SymbolicName="OPCUADINamespaceMetadata">
+    <DisplayName>http://opcfoundation.org/UA/DI/</DisplayName>
+    <Documentation>https://reference.opcfoundation.org/v105/DI/v103/docs/11.1</Documentation>
+    <References>
+      <Reference ReferenceType="HasProperty">ns=1;i=15002</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15003</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15004</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15005</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15006</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15007</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15008</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15031</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15032</Reference>
+      <Reference ReferenceType="HasProperty">ns=1;i=15033</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=11715</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=11616</Reference>
+    </References>
+  </UAObject>
+</UANodeSet>


### PR DESCRIPTION
This is a modified DI companion nodeset specification where the parent node with id **ns=1;i=15001** is defined after its child nodes:
 
- ns=1;i=15002
- ns=1;i=15003
- ns=1;i=15004
- ns=1;i=15005
- ns=1;i=15006
- ns=1;i=15007
- ns=1;i=15008
- ns=1;i=15031
- ns=1;i=15032
- ns=1;i=15033

This test XML is used for the ordering test case for open62541: [#5511](https://github.com/open62541/open62541/pull/5511)