### PR TITLE
[REVIEW] fix(tests): remove deprecated NAMESPACE_MAP from CMakeLists

### DIFF
--- a/backends/open62541/tests/dataTypeImport/CMakeLists.txt
+++ b/backends/open62541/tests/dataTypeImport/CMakeLists.txt
@@ -23,7 +23,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "struct"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/struct.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/struct.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/struct/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/struct.xml"
     INTERNAL
 )
@@ -42,7 +41,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "structExtended"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/structExtended.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/structExtended.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/struct/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/structExtended.xml"
     INTERNAL
 )
@@ -61,8 +59,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "specializedStruct"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/specializedstruct.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/specializedstruct.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/struct/"
-    NAMESPACE_MAP "3:http://yourorganisation.org/specializedStruct/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/specializedstruct.xml"
     DEPENDS "struct"
     INTERNAL
@@ -83,7 +79,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "optionalstruct"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/optionalstruct.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/optionalstruct.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/optionalStruct/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/optionalstruct.xml"
     INTERNAL
 )
@@ -102,7 +97,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "union"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/union.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/union.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/union/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/union.xml"
     INTERNAL
 )
@@ -121,7 +115,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "abstractdatatypemember"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/abstractdatatypemember.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/abstractdatatypemember.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/AbstractDataTypeMember/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/abstractdatatypemember.xml"
     INTERNAL
 )
@@ -142,7 +135,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "optionsetgen"
     FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/optionset.csv"
     FILE_BSD "${CMAKE_CURRENT_SOURCE_DIR}/optionset.bsd"
-    NAMESPACE_MAP "2:http://yourorganisation.org/optionSet/"
     FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/optionset.xml"
     INTERNAL
 )

--- a/backends/open62541/tests/integration/reference_server/CMakeLists.txt
+++ b/backends/open62541/tests/integration/reference_server/CMakeLists.txt
@@ -6,7 +6,6 @@ ua_generate_nodeset_and_datatypes(
     NAME "integration_test_di"
     FILE_CSV "${open62541_NODESET_BASE_DIR}/DI/Opc.Ua.Di.NodeIds.csv"
     FILE_BSD "${open62541_NODESET_BASE_DIR}/DI/Opc.Ua.Di.Types.bsd"
-    NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"
     FILE_NS "${open62541_NODESET_BASE_DIR}/DI/Opc.Ua.Di.NodeSet2.xml"
     INTERNAL
 )
@@ -25,7 +24,6 @@ ua_generate_datatypes(
     IMPORT_BSD "UA_TYPES#${open62541_NODESET_BASE_DIR}/Schema/Opc.Ua.Types.bsd"
     NAME "types83"
     TARGET_SUFFIX "types83"
-    NAMESPACE_MAP "3:http://opcfoundation.org/EM83/"
     FILE_CSV "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.csv"
     FILES_BSD "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.bsd"
 )
@@ -36,7 +34,6 @@ ua_generate_nodeset_and_datatypes(
     FILE_CSV "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.csv"
     FILE_BSD "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.bsd"
     IMPORT_BSD "UA_TYPES#${open62541_NODESET_BASE_DIR}/Schema/Opc.Ua.Types.bsd"
-    NAMESPACE_MAP "3:http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/"
     FILE_NS "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.xml"
     DEPENDS "integration_test_di"
     INTERNAL
@@ -48,7 +45,6 @@ ua_generate_nodeset_and_datatypes(
     FILE_CSV "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.IMM2MES.NodeSet2.csv"
     FILE_BSD "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.IMM2MES.NodeSet2.bsd"
     IMPORT_BSD "UA_TYPES#${open62541_NODESET_BASE_DIR}/Schema/Opc.Ua.Types.bsd"
-    NAMESPACE_MAP "4:http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/"
     FILE_NS "${PROJECT_SOURCE_DIR}/nodesets/euromap/Opc.Ua.PlasticsRubber.IMM2MES.NodeSet2.xml"
     DEPENDS "integration_test_euromap_83"
     INTERNAL


### PR DESCRIPTION
* deprecated with https://github.com/open62541/open62541/pull/6214
* relates to https://github.com/open62541/open62541/pull/6307

ping @NoelGraf 