### PR TITLE
fix: missing include of open62541/types_generated_handling.h

### DIFF
--- a/include/NodesetLoader/NodesetLoader.h
+++ b/include/NodesetLoader/NodesetLoader.h
@@ -10,6 +10,7 @@
 
 #include <open62541/types.h>
 #include <open62541/types_generated.h>
+#include <open62541/types_generated_handling.h>
 
 #include "Extension.h"
 #include "Logger.h"


### PR DESCRIPTION
Fix compile errors due to missing include of `<open62541/types_generated_handling.h>`.

Excerpt of compile errors:
```
/home/lb/dev/open62541-nodeset-loader/src/AliasList.c: In function ‘AliasList_newAlias’:
/home/lb/dev/open62541-nodeset-loader/src/AliasList.c:43:5: error: implicit declaration of function ‘UA_NodeId_init’; did you mean ‘UA_NodeId_print’? [-Werror=implicit-function-declaration]
   43 |     UA_NodeId_init(&list->data[list->size].id);
      |     ^~~~~~~~~~~~~~
      |     UA_NodeId_print
```